### PR TITLE
Add examples in the documentation

### DIFF
--- a/src/Any/Clean.ts
+++ b/src/Any/Clean.ts
@@ -25,6 +25,12 @@ type ArrayProps = keyof any[] | ArrayEntry     // so this matches any entry, whe
  * @returns [[Object]]
  * @example
  * ```ts
+ * import {A} from 'ts-toolbelt'
+ *
+ * type test0 = A.Compute<{a: string} & number[]> // {[x: number]: number, a: string, length: number, toString...}
+ * type test1 = A.Compute<{a: string} & [1, 2]> // {[x: number]: 2 | 1, a: string, 0: 1, 1: 2, length: 2, toString...}
+ * type test2 = A.Clean<test0> // {a: string} & number[]
+ * type test3 = A.Clean<test1> // {a: string} & [1, 2]
  * ```
  */
 export type Clean<A extends any> =

--- a/src/Any/Kind.ts
+++ b/src/Any/Kind.ts
@@ -19,6 +19,13 @@ type _Kind<A extends any> =
  * @returns `'string' | 'number' | 'function' | 'array' | 'object' | 'boolean' | 'unknown'`
  * @example
  * ```ts
+ * import {A} from 'ts-toolbelt'
+ *
+ * type test0 = A.Kind<'hello'> // 'string'
+ * type test1 = A.Kind<42> // 'number'
+ * type test2 = A.Kind<[1, 2, 3]> // 'array'
+ * type test3 = A.Kind<{a: string}> // 'object'
+ * type test4 = A.Kind<() => {}> // 'function'
  * ```
  */
 export type Kind<A extends any> =

--- a/src/Any/Promisable.ts
+++ b/src/Any/Promisable.ts
@@ -6,6 +6,16 @@ import {Promise} from '../Any/Promise'
  * @param A Any type
  * @returns `A | Promise<A>`
  * @example
+ * ```ts
+ * import {A} from 'ts-toolbelt'
+ *
+ * declare function generateRandomNumber(): A.Promisable<number>
+ *
+ * const res0 = await generateRandomNumber()
+ * const res1 = await generateRandomNumber()
+ *
+ * console.log(res0 < res1)
+ * ```
  */
 export type Promisable<A extends any> =
     A | Promise<A>

--- a/src/Any/Promise.ts
+++ b/src/Any/Promise.ts
@@ -2,6 +2,13 @@
  * Create an asynchronous operation like the original `Promise` type but this
  * one prevents promises to be wrapped within more promises (not possible).
  * @param A
+ * @example
+ * ```ts
+ * import {A} from 'ts-toolbelt'
+ *
+ * type test0 = A.Promise<Promise<number>> // Promise<number>
+ * type test1 = Promise<Promise<number>> // Promise<Promise<number>>
+ * ```
  */
 export type Promise<A extends any> =
     globalThis.Promise<

--- a/src/Class/Class.ts
+++ b/src/Class/Class.ts
@@ -5,6 +5,16 @@ import {List} from '../List/List'
  * @param P its constructor parameters
  * @param R the object it constructs
  * @returns `class`
+ * @example
+ * ```ts
+ * import {C} from 'ts-toolbelt'
+ *
+ * type test0 = C.Class<[string, number], {a: string, b: number}>
+ *
+ * declare const SomeClass: test0
+ *
+ * const obj = new SomeClass('foo', 42) // {a: string, b: number}
+ * ```
  */
 export type Class<P extends List = any[], R extends object = object> = {
     new (...args: P): R

--- a/src/Class/Parameters.ts
+++ b/src/Class/Parameters.ts
@@ -1,12 +1,17 @@
 import {Class} from './Class'
 
 /**
-Get the parameters of a class constructor
-@param C **typeof** class
-@returns [[List]]
-@example
-```ts
-```
+ * Get the parameters of a class constructor
+ * @param C **typeof** class
+ * @returns [[List]]
+ * @example
+ * ```ts
+ * import {C} from 'ts-toolbelt'
+ *
+ * type User = C.Class<[string, string], {firstname: string, lastname: string}>
+ *
+ * type test0 = C.Parameters<User> // [string, string]
+ * ```
 */
 export type Parameters<C extends Class> =
     C extends Class<infer P, any>

--- a/src/Function/UnCurry.ts
+++ b/src/Function/UnCurry.ts
@@ -1,12 +1,23 @@
 import {Curry} from './Curry'
 
 /**
-Undoes the work that was done by [[Curry]]
-@param F to uncurry
-@returns [[Function]]
-@example
-@ignore
-*/
+ * Undoes the work that was done by [[Curry]]
+ * @param F to uncurry
+ * @returns [[Function]]
+ * @example
+ * ```ts
+ * import {F} from 'ts-toolbelt'
+ *
+ * type test0 = F.Curry<(a: string, b: number) => boolean>
+ * declare const foo: test0
+ * const res0 = foo('a') // F.Curry<(b: number) => boolean> & ((b: number) => boolean)
+ *
+ * type test1 = F.UnCurry<test0> // (a: string, b: number) => boolean
+ * declare const bar: test1
+ * const res1 = bar('a') // TS2554: Expected 2 arguments, but got 1.
+ * ```
+ * @ignore
+ */
 export type UnCurry<F extends Curry<any>> =
     F extends Curry<infer UF>
     ? UF

--- a/src/List/Append.ts
+++ b/src/List/Append.ts
@@ -1,13 +1,19 @@
 import {List} from './List'
 
 /**
-Add an element `A` at the end of `L`
-@param L to append to
-@param A to be added to
-@returns [[List]]
-@example
-```ts
-```
-*/
+ * Add an element `A` at the end of `L`.
+ * @param L to append to
+ * @param A to be added to
+ * @returns [[List]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = L.Append<[1, 2, 3], 4> // [1, 2, 3, 4]
+ * type test1 = L.Append<[], 'a'> // ['a']
+ * type test2 = L.Append<readonly ['a', 'b'], 'c'> // ['a', 'b', 'c']
+ * type test3 = L.Append<[1, 2], [3, 4]> // [1, 2, [3, 4]]
+ * ```
+ */
 export type Append<L extends List, A extends any> =
     [...L, A]

--- a/src/List/Assign.ts
+++ b/src/List/Assign.ts
@@ -5,16 +5,21 @@ import {ListOf} from '../Object/ListOf'
 import {Depth} from '../Object/_Internal'
 
 /**
-Assign a list of [[List]] into `L` with [[Merge]]. Merges from left to
-right, first items get overridden by the next ones (last-in overrides).
-@param L to assign to
-@param Ls to assign
-@param depth (?=`'flat'`) to do it deeply
-@returns [[Object]]
-@example
-```ts
-```
-*/
+ * Assign a list of [[List]] into `L` with [[Merge]]. Merges from left to
+ * right, first items get overridden by the next ones (last-in overrides).
+ * @param L to assign to
+ * @param Ls to assign
+ * @param depth (?=`'flat'`) to do it deeply
+ * @returns [[Object]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = Assign<[1, 2, 3], [[2, 1]]> // [2, 1, 3]
+ * type test1 = Assign<[], [[1, 2, 3, 4], [2, 4, 6]]> // [2, 4, 6, 4]
+ * type test2 = Assign<[0, 0, 0, 0, 0], [[0, 1], [0, 2, 0, 4?]]> // [0, 2, 0, 0 | 4, 0]
+ * ```
+ */
 export type Assign<L extends List, Ls extends List<List>, depth extends Depth = 'flat'> =
     ListOf<OAssign<ObjectOf<L>, {[K in keyof Ls]: ObjectOf<Ls[K] & List>}, depth>>
     // in the mapped type above, we make sure tuples are not left with array properties

--- a/src/List/At.ts
+++ b/src/List/At.ts
@@ -4,12 +4,18 @@ import {List} from './List'
 import {Boolean} from '../Boolean/Boolean'
 
 /**
-Get in `L` the type of an entry of key `K`
-@param L to extract from
-@param K to extract at
-@param strict (?=`1`) `0` to work with unions
-@returns [[Any]]
-@example
-*/
+ * Get in `L` the type of an entry of key `K`.
+ * @param L to extract from
+ * @param K to extract at
+ * @param strict (?=`1`) `0` to work with unions
+ * @returns [[Any]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = L.At<[1, 2, 3], 1> // 2
+ * type test1 = L.At<[{a: string}, {b: string}], 0> // {a: string}
+ * ```
+ */
 export type At<L extends List, K extends Key, strict extends Boolean = 1> =
     OAt<L, K, strict>

--- a/src/List/AtLeast.ts
+++ b/src/List/AtLeast.ts
@@ -7,14 +7,23 @@ import {NumberOf} from '../Any/_Internal'
 import {Keys} from './Keys'
 
 /**
-Make that at least one of the keys `K` are required in `L` at a time.
-@param L to make required
-@param K (?=`keyof L`) to choose fields
-@returns [[List]] [[Union]]
-@example
-```ts
-```
-*/
+ * Make that at least one of the keys `K` are required in `L` at a time.
+ * @param L to make required
+ * @param K (?=`keyof L`) to choose fields
+ * @returns [[List]] [[Union]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = L.AtLeast<[1, 2, 3], 0> // [1, 2 | undefined, 3 | undefined]
+ * type test1 = L.AtLeast<[1, 2, 3], 0 | 1> // [1, 2 | undefined, 3 | undefined] | [1 | undefined, 2, 3 | undefined]
+ * type test2 = L.AtLeast<[1, 2, 3]>
+ * // | [1, 2, 3]
+ * // | [1, 2 | undefined, 3 | undefined]
+ * // | [1 | undefined, 2, 3 | undefined]
+ * // | [1 | undefined, 2 | undefined, 3]
+ * ```
+ */
 export type AtLeast<L extends List, K extends Key = Keys<L>> =
     OAtLeast<ObjectOf<L>, NumberOf<K>> extends infer U
     ? U extends unknown // we distribute over the union

--- a/src/List/Compulsory.ts
+++ b/src/List/Compulsory.ts
@@ -1,17 +1,20 @@
 import {Depth} from '../Object/_Internal'
 import {CompulsoryPart} from '../Object/Compulsory'
 import {List} from './List'
-import {_Pick} from '../Object/Pick'
 
 /**
-Make that `L`'s fields cannot be [[Nullable]] or [[Optional]] (it's like
-[[Required]] & [[NonNullable]] at once).
-@param L to make compulsory
-@param depth (?=`'flat'`) to do it deeply
-@returns [[List]]
-@example
-```ts
-```
-*/
+ * Make that `L`'s fields cannot be [[Nullable]] or [[Optional]] (it's like
+ * [[Required]] & [[NonNullable]] at once).
+ * @param L to make compulsory
+ * @param depth (?=`'flat'`) to do it deeply
+ * @returns [[List]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = L.Compulsory<[1, 2, 3?, 4?]> // [1, 2, 3, 4]
+ * type test1 = L.Compulsory<['a', 'b' | undefined, 'c', 'd', 'e' | null]> // ['a', 'b', 'c', 'd', 'e']
+ * ```
+ */
 export type Compulsory<L extends List, depth extends Depth = 'flat'> =
     CompulsoryPart<L, depth>

--- a/src/List/CompulsoryKeys.ts
+++ b/src/List/CompulsoryKeys.ts
@@ -3,14 +3,17 @@ import {ObjectOf} from './ObjectOf'
 import {List} from './List'
 
 /**
-Get the keys of `L` that are [[Compulsory]]
-
-(⚠️ needs `--strictNullChecks` enabled)
-@param L
-@returns [[Key]]
-@example
-```ts
-```
-*/
+ * Get the keys of `L` that are [[Compulsory]].
+ *
+ * (⚠️ needs `--strictNullChecks` enabled)
+ * @param L
+ * @returns [[Key]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = L.CompulsoryKeys<[1, 2, 3]> // {0: 1, 1: 2, 2: 3}
+ * ```
+ */
 export type CompulsoryKeys<L extends List> =
     OCompulsory<ObjectOf<L>>

--- a/src/List/Concat.ts
+++ b/src/List/Concat.ts
@@ -1,13 +1,19 @@
 import {List} from './List'
 
 /**
-Attach `L1` at the end of `L`
-@param L to concat with
-@param L1 to be attached
-@returns [[List]]
-@example
-```ts
-```
-*/
+ * Attach `L1` at the end of `L`.
+ * @param L to concat with
+ * @param L1 to be attached
+ * @returns [[List]]
+ * @example
+ * ```ts
+ * import {L} from 'ts-toolbelt'
+ *
+ * type test0 = L.Concat<[1, 2], [3, 4]> // [1, 2, 3, 4]
+ * type test1 = L.Concat<[1, 2], [[3], 4]> // [1, 2, [3], 4]
+ * type test2 = L.Concat<[1, 2], number[]> // [1, 2, ...number[]]
+ * type test3 = L.Concat<readonly [1, 2], readonly [3]> // [1, 2, 3]
+ * ```
+ */
 export type Concat<L extends List, L1 extends List> =
     [...L, ...L1]


### PR DESCRIPTION
## 🎁 Pull Request

* [x] Used a clear / meaningful title for this pull request
* [x] Tested the changes in your own code (on your projects)
* [ ] Added / Edited tests to reflect changes (`tst` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

#### Fixes
Nothing.

#### Why have you made changes?
To improve the documentation and hopefully bring more people to the joys of type-level programming.

#### What changes have you made?
I added examples in the documentation blocks of some types.

I'll probably add more examples in the near future, I want to make sure these kinds of changes are welcome!

#### What tests have you updated?
None.

#### Is there any breaking changes?
No.

#### Anything else worth mentioning?
While playing with `L.CompulsoryKeys`, I got some strange results:

```ts
import {L} from 'ts-toolbelt'

type test0 = L.CompulsoryKeys<[1, 2, 3]> // {0: 1, 1: 2, 2: 3}
```

I was expecting to get `0 | 1 | 2` instead. I also tested with `[1, 2, 3?]` and got the exact same result, while expecting `0 | 1`. Nonetheless I added the example, but I'm pretty sure the result is wrong, and there are no tests for this mapped type (there's a "cf. O.CompulsoryKeys" in the `tst/List.ts` file).

Also, I didn't follow the 7th step of the contributing guide (the one that mentions `npm run release -- --no-tags`) since it's only about documentation.