### PR TITLE
Fix #208 - O.Invert doesn't work for interfaces (just for types)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,8 +21,8 @@
 * ...
 
 #### What tests have you updated?
-* tested this in `tst/...`
-* tested that in `tst/...`
+* tested this in `tests/...`
+* tested that in `tests/...`
 * ...
 
 #### Is there any breaking changes?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 <!-- Fill the following checklist. -->
 * [ ] Used a clear / meaningful title for this pull request
 * [ ] Tested the changes in your own code (on your projects)
-* [ ] Added / Edited tests to reflect changes (`tst` folder)
+* [ ] Added / Edited tests to reflect changes (`tests` folder)
 * [ ] Have read the **Contributing** part of the **Readme**
 * [ ] Passed `npm test`
 

--- a/sources/Object/Invert.ts
+++ b/sources/Object/Invert.ts
@@ -41,7 +41,7 @@ export type _Invert<O extends Record<Key, Key>> =
  * type test1 = O.Invert<O>
  * ```
  */
-export type Invert<O extends Record<Key, Key>> =
+export type Invert<O extends Record<keyof O, Key>> =
     O extends unknown
     ? _Invert<O>
     : never

--- a/tests/Object.ts
+++ b/tests/Object.ts
@@ -426,34 +426,67 @@ checks([
 // INVERT
 
 const INVERT_SYM = Symbol('')
+const INVERT_SYM2 = Symbol('')
 
-type O_INVERT = {
+type O_INVERT_T1 = {
     A: 'Av';
     B: typeof INVERT_SYM;
     C: 42;
 };
 
-type INVERT_O = {
+type O_INVERT_T2 = O_INVERT_T1 | {
+    Af: 'Avf';
+    Bf: typeof INVERT_SYM2;
+    Cf: 43;
+};
+
+type T1_INVERT_O = {
     Av: 'A';
     [INVERT_SYM]: 'B';
     42: 'C';
 };
 
-interface O_INVERT1 {
+type T2_INVERT_O = {
+    Av: 'A';
+    [INVERT_SYM]: 'B';
+    42: 'C';
+} | {
+    Avf: 'Af';
+    [INVERT_SYM2]: 'Bf';
+    43: 'Cf';
+};
+
+interface O_INVERT_I1 {
     A: 'Av';
     B: typeof INVERT_SYM;
     C: 42;
 }
 
-interface INVERT1_O {
+interface O_INVERT_I2 {
+    Af: 'Avf';
+    Bf: typeof INVERT_SYM2;
+    Cf: 43;
+}
+
+interface I1_INVERT_O {
     Av: 'A';
     [INVERT_SYM]: 'B';
     42: 'C';
+}
+
+interface I2_INVERT_O {
+    Avf: 'Af';
+    [INVERT_SYM2]: 'Bf';
+    43: 'Cf';
 }
 
 checks([
-    check<O.Invert<O_INVERT>, INVERT_O, Test.Pass>(),
-    check<O.Invert<O_INVERT1>, INVERT1_O, Test.Pass>(),
+    check<O.Invert<O_INVERT_T1>, T1_INVERT_O, Test.Pass>(),
+    check<O.Invert<O_INVERT_T2>, T2_INVERT_O, Test.Pass>(),
+    check<O.Invert<O_INVERT_I1>, T1_INVERT_O, Test.Pass>(),
+    check<O.Invert<O_INVERT_I1>, I1_INVERT_O, Test.Pass>(),
+    check<O.Invert<O_INVERT_I1 | O_INVERT_I2>, T2_INVERT_O, Test.Pass>(),
+    check<O.Invert<O_INVERT_I1 | O_INVERT_I2>, I1_INVERT_O | I2_INVERT_O, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------

--- a/tests/Object.ts
+++ b/tests/Object.ts
@@ -428,8 +428,8 @@ checks([
 const INVERT_SYM = Symbol('')
 
 type O_INVERT = {
-    A: 'Av',
-    B: typeof INVERT_SYM,
+    A: 'Av';
+    B: typeof INVERT_SYM;
     C: 42;
 };
 
@@ -439,8 +439,21 @@ type INVERT_O = {
     42: 'C';
 };
 
+interface O_INVERT1 {
+    A: 'Av';
+    B: typeof INVERT_SYM;
+    C: 42;
+}
+
+interface INVERT1_O {
+    Av: 'A';
+    [INVERT_SYM]: 'B';
+    42: 'C';
+}
+
 checks([
     check<O.Invert<O_INVERT>, INVERT_O, Test.Pass>(),
+    check<O.Invert<O_INVERT1>, INVERT1_O, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## 🎁 Pull Request

* [x] Used a clear / meaningful title for this pull request
* [x] Tested the changes in your own code (on your projects)
* [x] Added / Edited tests to reflect changes (`tests` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

#### Fixes
#208

#### Why have you made changes?
To fix the issue so O.Invert can support interfaces as well. Basically a revert of [73b8948e](https://github.com/millsp/ts-toolbelt/commit/73b8948ea1d49e05ae8c63b17926eda4cb04e9bb)  which caused the issue to appear.

#### What changes have you made?
I have restricted the type space of the keys of the Record constraint so it will not force an index signature to exist on the generic type O
Bonus - I also fixed the PR template to point to the correct tests dir :-)

#### What tests have you updated?
* tested this in `tests/Object.ts` under the INVERT section (line 426)

#### Is there any breaking changes?
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [x] No,  I added to the existing tests
* [ ] I don't know
