### PR TITLE
feat(paths): parameter for AutoPath delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [9.6.0](https://github.com/millsp/ts-toolbelt/compare/v9.5.1...v9.6.0) (2021-03-04)
+
+
+### Features
+
+* **paths:** parameter for AutoPath delimiter ([6d5bbdc](https://github.com/millsp/ts-toolbelt/commit/6d5bbdc834ce15dd3339d101c828457b1a34cce4))
+
+
+### Bug Fixes
+
+* **f.narrow:** variance ([866ecd7](https://github.com/millsp/ts-toolbelt/commit/866ecd76744fc38244d85e7ef7b4bb90105cf7eb))
+* **fn:** allow for curried in compose ([2bc5604](https://github.com/millsp/ts-toolbelt/commit/2bc560446916b423977c25e396b4f1f310b6c03f))
+
+
+### Others
+
+* **release:** 9.5.2 ([ec4a953](https://github.com/millsp/ts-toolbelt/commit/ec4a953cabe6c4d704c0dca5f37d1dc630de047b))
+* **release:** 9.5.3 ([0836f6e](https://github.com/millsp/ts-toolbelt/commit/0836f6e8187287a0c86f249e4e552d68a44e4f60))
+
 ### [9.5.3](https://github.com/millsp/ts-toolbelt/compare/v9.5.1...v9.5.3) (2021-03-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-toolbelt",
-  "version": "9.5.3",
+  "version": "9.6.0",
   "description": "TypeScript's largest utility library",
   "keywords": [
     "safe",

--- a/sources/Function/AutoPath.ts
+++ b/sources/Function/AutoPath.ts
@@ -12,64 +12,80 @@ import {Split} from '../String/Split'
 /**
  * @ignore
  */
-type Index = (number | string)
+type Index = number | string;
 
 /**
  * @ignore
  */
-type KeyToIndex<K extends Key, SP extends List<Index>> =
-    number extends K ? Head<SP> : K & Index
+type KeyToIndex<K extends Key, SP extends List<Index>> = number extends K
+  ? Head<SP>
+  : K & Index;
 
 /**
  * @ignore
  */
-type MetaPath<O, SP extends List<Index> = [], P extends List<Index> = []> = {
-    [K in keyof O]:
-    | MetaPath<O[K] & {}, Tail<SP>, [...P, KeyToIndex<K, SP>]>
-    | Join<[...P, KeyToIndex<K, SP>], '.'>
-}
+type MetaPath<
+  O,
+  Delimiter extends string,
+  SP extends List<Index> = [],
+  P extends List<Index> = []
+> = {
+  [K in keyof O]:
+    | MetaPath<O[K] & {}, Delimiter, Tail<SP>, [...P, KeyToIndex<K, SP>]>
+    | Join<[...P, KeyToIndex<K, SP>], Delimiter>;
+};
 
 /**
  * @ignore
  */
 type NextPath<OP> =
-    // the next paths after property `K` are on sub objects
-    // O[K] === K | {x: '${K}.x' | {y: '${K}.x.y' ...}}
-    // So we access O[K] then we only keep the next paths
-    // To do this, we can just exclude `string` out of it:
-    // O[K] === {x: '${K}.x' | {y: '${K}.x.y' ...}}
-    // To do this, we create a union of what we just got
-    // This will yield a union of paths and meta paths
-    // We exclude the next paths (meta) paths by excluding
-    // `object`. Then we are left with the direct next path
-    Select<UnionOf<Exclude<OP, string> & {}>, string>
+  // the next paths after property `K` are on sub objects
+  // O[K] === K | {x: '${K}.x' | {y: '${K}.x.y' ...}}
+  // So we access O[K] then we only keep the next paths
+  // To do this, we can just exclude `string` out of it:
+  // O[K] === {x: '${K}.x' | {y: '${K}.x.y' ...}}
+  // To do this, we create a union of what we just got
+  // This will yield a union of paths and meta paths
+  // We exclude the next paths (meta) paths by excluding
+  // `object`. Then we are left with the direct next path
+  Select<UnionOf<Exclude<OP, string> & {}>, string>;
 
 /**
  * @ignore
  */
-type ExecPath<A, SP extends List<Index>> =
-    // We go in the `MetaPath` of `O` to get the prop at `SP`
-    // So we query what is going the `NextPath` at `O[...SP]`
-    NextPath<Path<MetaPath<A, SP>, SP>>
+type ExecPath<A, SP extends List<Index>, Delimiter extends string> =
+  // We go in the `MetaPath` of `O` to get the prop at `SP`
+  // So we query what is going the `NextPath` at `O[...SP]`
+  NextPath<Path<MetaPath<A, Delimiter, SP>, SP>>;
 
 /**
  * @ignore
  */
-type HintPath<A, P extends string, SP extends List<Index>, Exec extends string> =
-    [Exec] extends [never] // if has not found paths
-    ? ExecPath<A, Pop<SP>> // display previous paths
-    : Exec | P             // display current + next
+type HintPath<
+  A,
+  P extends string,
+  SP extends List<Index>,
+  Exec extends string,
+  Delimiter extends string
+> = [Exec] extends [never] // if has not found paths
+  ? ExecPath<A, Pop<SP>, Delimiter> // display previous paths
+  : Exec | P; // display current + next
 
 /**
  * @ignore
  */
-type _AutoPath<A, P extends string, SP extends List<Index> = Split<P, '.'>> =
-    HintPath<A, P, SP, ExecPath<A, SP>>
+type _AutoPath<
+  A,
+  P extends string,
+  Delimiter extends string,
+  SP extends List<Index> = Split<P, Delimiter>
+> = HintPath<A, P, SP, ExecPath<A, SP, Delimiter>, Delimiter>;
 
 /**
  * Auto-complete, validate, and query the string path of an object `O`
  * @param O to work on
  * @param P path of `O`
+ * @param Delimiter delimiter for path (default is ".")
  *
  * ```ts
  * declare function get<O extends object, P extends string>(
@@ -92,5 +108,8 @@ type _AutoPath<A, P extends string, SP extends List<Index> = Split<P, '.'>> =
  * const friendFriendNames = get(user, 'friends.40.friends.12.names')
  * ```
  */
-export type AutoPath<O extends any, P extends string> =
-    _AutoPath<O & {}, P>
+export type AutoPath<
+  O extends any,
+  P extends string,
+  Delimiter extends string = '.'
+> = _AutoPath<O & {}, P, Delimiter>;

--- a/tests/Function.ts
+++ b/tests/Function.ts
@@ -120,6 +120,7 @@ checks([
     check<F.AutoPath<O_PATHAUTO, 'b.'>, 'b.b' | 'b.a', Test.Pass>(),
     check<F.AutoPath<O_PATHAUTO, 'b.b.0'>, 'b.b.0' | 'b.b.0.b' | 'b.b.0.a', Test.Pass>(),
     check<F.AutoPath<O_PATHAUTO, 'b.b.0.a'>, 'b.b.0.a' | 'b.b.0.a.a', Test.Pass>(),
+    check<F.AutoPath<O_PATHAUTO, 'b/b/0/a', '/'>, 'b/b/0/a' | 'b/b/0/a/a', Test.Pass>(),
     check<F.AutoPath<O_PATHAUTO, 'b.b.0.a'>, 'b.b.0.a' | 'b.b.x.a.a', Test.Fail>(),
     check<F.AutoPath<O_PATHAUTO, 'b.b.0.a'>, 'b.b.0.a' | 'b.b.a.a', Test.Fail>(),
     check<F.AutoPath<GlobalEventHandlersEventMap, 'cancel.isTrusted.'>, 'cancel.isTrusted.valueOf', Test.Pass>(),


### PR DESCRIPTION
## 🎁 Pull Request

<!-- Fill the following checklist. -->
* [x] Used a clear / meaningful title for this pull request
* [x] Tested the changes in your own code (on your projects)
* [x] Added / Edited tests to reflect changes (`tst` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

<!-- Complete the following parts. -->

#### Why have you made changes?
<!-- A clear & concise explanation. -->
Users may want to leverage AutoPath for strings delimited by something other than "."

#### What changes have you made?
* Added an additional "Delimiter" parameter to the AutoPath generic (defaults to ".")

#### What tests have you updated?
* tested the Delimiter parameter in "tests/Function.ts"

#### Is there any breaking changes?
<!-- Fill the following checklist. -->
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [x] No,  I added to the public API & documented it
* [x] No,  I added to the existing tests
* [ ] I don't know

#### Anything else worth mentioning?
<!-- Please help with the PR process. -->
<!-- Leave any extra useful information. -->
<!-- Or mention someone who is concerned. -->
