### PR TITLE
Add to O.Paths the ability to exclude custom types and to get all available paths

### DIFF
--- a/sources/Object/Paths.ts
+++ b/sources/Object/Paths.ts
@@ -50,6 +50,8 @@ type _Paths<O, P extends List, Required extends Boolean, Ignore> = {
  * Get all the possible paths of `O`
  * (⚠️ this won't work with circular-refs)
  * @param O to be inspected
+ * @param Required indicate if you want all possible individual paths
+ * @param Ignore types to avoid inspecting their paths
  * @returns [[String]][]
  * @example
  * ```ts

--- a/sources/Object/Paths.ts
+++ b/sources/Object/Paths.ts
@@ -18,7 +18,7 @@ type PathMode = 'compact' | 'all' | 'required'
 type UnionOf<A> =
     A extends List
     ? A[number]
-    : A[keyof A]
+    : Exclude<A[keyof A], undefined>
 
 /**
  * @hidden

--- a/sources/Object/Paths.ts
+++ b/sources/Object/Paths.ts
@@ -6,7 +6,7 @@ import {BuiltIn} from '../Misc/BuiltIn'
 import {Primitive} from '../Misc/Primitive'
 import {Length} from '../List/Length'
 import {Keys} from '../Any/Keys'
-import {Boolean} from '../Boolean/_Internal';
+import {Boolean} from '../Boolean/_Internal'
 
 /**
  * @hidden

--- a/sources/Object/Paths.ts
+++ b/sources/Object/Paths.ts
@@ -1,11 +1,12 @@
 import {Key} from '../Any/Key'
-import {NonNullableFlat} from '../Object/NonNullable'
+import {NonNullableFlat} from './NonNullable'
 import {Cast} from '../Any/Cast'
 import {List} from '../List/List'
 import {BuiltIn} from '../Misc/BuiltIn'
 import {Primitive} from '../Misc/Primitive'
 import {Length} from '../List/Length'
 import {Keys} from '../Any/Keys'
+import {Boolean} from '../Boolean/_Internal';
 
 /**
  * @hidden
@@ -18,13 +19,32 @@ type UnionOf<A> =
 /**
  * @hidden
  */
-type _Paths<O, P extends List = []> = UnionOf<{
+type _PathsOptional<O, P extends List, Ignore> = UnionOf<{
     [K in keyof O]:
-    O[K] extends BuiltIn | Primitive ? NonNullableFlat<[...P, K?]> :
+    O[K] extends BuiltIn | Primitive | Ignore ? NonNullableFlat<[...P, K?]> :
     [Keys<O[K]>] extends [never] ? NonNullableFlat<[...P, K?]> :
     12 extends Length<P> ? NonNullableFlat<[...P, K?]> :
-    _Paths<O[K], [...P, K?]>
+    _PathsOptional<O[K], [...P, K?], Ignore>
 }>
+
+/**
+ * @hidden
+ */
+type _PathsRequired<O, P extends List, Ignore> = UnionOf<{
+    [K in keyof O]:
+    O[K] extends BuiltIn | Primitive | Ignore ? NonNullableFlat<[...P, K]> :
+    [Keys<O[K]>] extends [never] ? NonNullableFlat<[...P, K]> :
+    12 extends Length<P> ? NonNullableFlat<[...P, K]> :
+    NonNullableFlat<[...P, K]> | _PathsRequired<O[K], [...P, K], Ignore>
+}>
+
+/**
+ * @hidden
+ */
+type _Paths<O, P extends List, Required extends Boolean, Ignore> = {
+    0: _PathsOptional<O, P, Ignore>;
+    1: _PathsRequired<O, P, Ignore>;
+}[Required]
 
 /**
  * Get all the possible paths of `O`
@@ -35,7 +55,7 @@ type _Paths<O, P extends List = []> = UnionOf<{
  * ```ts
  * ```
  */
-export type Paths<O, P extends List = []> =
-    _Paths<O, P> extends infer X
+export type Paths<O, P extends List = [], Required extends Boolean = 0, Ignore = never> =
+    _Paths<O, P, Required, Ignore> extends infer X
     ? Cast<X, List<Key>>
     : never

--- a/tests/Object.ts
+++ b/tests/Object.ts
@@ -1067,20 +1067,26 @@ type O_PATHS_DEEP = {
             g: {
                 f: number;
             };
+            h: {r: number}[],
         };
     };
 };
 
-
 checks([
+    // Default compact mode
     check<O.Paths<{'prop': {a: 1}[]}>, T.NonNullable<['prop'?, number?, 'a'?]>, Test.Pass>(),
     check<O.Paths<O_PATHS>, T.NonNullable<['a'?, 'a'?] | ['b'?, 'a'?, 'a'?] | ['b'?, 'b'?] | ['c'?]>, Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?, 'e'?] | ['a'?, 'b'?, 'g'?, 'f'?]>, Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP, [], 0, { e: number; } | { f: number; }>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?] | ['a'?, 'b'?, 'g'?]>, Test.Pass>(),
-    check<O.Paths<O[]>, O.Paths<O[]>, Test.Pass>(),
-    check<O.Paths<{'prop': {a: 1}[]}, [], 1>, ['prop'] | ['prop', number] | ['prop', number, 'a'], Test.Pass>(),
-    check<O.Paths<O_PATHS, [], 1>, ['a'] | ['a', 'a'] | ['b'] | ['b', 'a'] | ['b', 'a', 'a'] | ['b', 'b'] | ['c'], Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP, [], 1, { e: number; } | { f: number; }>, ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?, 'e'?] | ['a'?, 'b'?, 'g'?, 'f'?] | ['a'?, 'b'?, 'h'?, number?, 'r'?]>, Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'compact', { e: number; } | { f: number; }>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?] | ['a'?, 'b'?, 'g'?] | ['a'?, 'b'?, 'h'?, number?, 'r'?]>, Test.Pass>(),
+    // All mode
+    check<O.Paths<{'prop': {a: 1}[]}, [], 'all'>, ['prop'] | ['prop', number] | ['prop', number, 'a'], Test.Pass>(),
+    check<O.Paths<O_PATHS, [], 'all'>, ['a'] | ['a', 'a'] | ['b'] | ['b', 'a'] | ['b', 'a', 'a'] | ['b', 'b'] | ['c'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'all', { e: number; } | { f: number; }>, ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'] | ['a', 'b', 'h'] | ['a', 'b', 'h', number] | ['a', 'b', 'h', number, 'r'], Test.Pass>(),
+    // Required mode
+    check<O.Paths<{'prop': {a: 1}[]}, [], 'required'>, ['prop', number, 'a'], Test.Pass>(),
+    check<O.Paths<O_PATHS, [], 'required'>, ['a', 'a'] | ['b', 'a', 'a'] | ['b', 'b'] | ['c'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'required', { e: number; } | { f: number; }>, ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'] | ['a', 'b', 'h', number, 'r'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'required', { e: number; } | { f: number; }, string>, ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'], Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------

--- a/tests/Object.ts
+++ b/tests/Object.ts
@@ -1057,10 +1057,30 @@ type O_PATHS = {
     c: boolean
 };
 
+type O_PATHS_DEEP = {
+    a: {
+        b: {
+            c: Date;
+            d: {
+                e: number;
+            };
+            g: {
+                f: number;
+            };
+        };
+    };
+};
+
+
 checks([
     check<O.Paths<{'prop': {a: 1}[]}>, T.NonNullable<['prop'?, number?, 'a'?]>, Test.Pass>(),
     check<O.Paths<O_PATHS>, T.NonNullable<['a'?, 'a'?] | ['b'?, 'a'?, 'a'?] | ['b'?, 'b'?] | ['c'?]>, Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?, 'e'?] | ['a'?, 'b'?, 'g'?, 'f'?]>, Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 0, { e: number; } | { f: number; }>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?] | ['a'?, 'b'?, 'g'?]>, Test.Pass>(),
     check<O.Paths<O[]>, O.Paths<O[]>, Test.Pass>(),
+    check<O.Paths<{'prop': {a: 1}[]}, [], 1>, ['prop'] | ['prop', number] | ['prop', number, 'a'], Test.Pass>(),
+    check<O.Paths<O_PATHS, [], 1>, ['a'] | ['a', 'a'] | ['b'] | ['b', 'a'] | ['b', 'a', 'a'] | ['b', 'b'] | ['c'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 1, { e: number; } | { f: number; }>, ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'], Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------

--- a/tests/Object.ts
+++ b/tests/Object.ts
@@ -1062,31 +1062,32 @@ type O_PATHS_DEEP = {
         b: {
             c: Date;
             d: {
-                e: number;
+                e: number | null;
             };
             g: {
-                f: number;
+                f: number | undefined;
             };
             h: {r: number}[],
         };
     };
+    v?: boolean;
 };
 
 checks([
     // Default compact mode
     check<O.Paths<{'prop': {a: 1}[]}>, T.NonNullable<['prop'?, number?, 'a'?]>, Test.Pass>(),
     check<O.Paths<O_PATHS>, T.NonNullable<['a'?, 'a'?] | ['b'?, 'a'?, 'a'?] | ['b'?, 'b'?] | ['c'?]>, Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?, 'e'?] | ['a'?, 'b'?, 'g'?, 'f'?] | ['a'?, 'b'?, 'h'?, number?, 'r'?]>, Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP, [], 'compact', { e: number; } | { f: number; }>, T.NonNullable<['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?] | ['a'?, 'b'?, 'g'?] | ['a'?, 'b'?, 'h'?, number?, 'r'?]>, Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP>, T.NonNullable<['v'?] | ['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?, 'e'?] | ['a'?, 'b'?, 'g'?, 'f'?] | ['a'?, 'b'?, 'h'?, number?, 'r'?]>, Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'compact', { e: number | null; } | { f: number | undefined; }>, T.NonNullable<['v'?] | ['a'?, 'b'?, 'c'?] | ['a'?, 'b'?, 'd'?] | ['a'?, 'b'?, 'g'?] | ['a'?, 'b'?, 'h'?, number?, 'r'?]>, Test.Pass>(),
     // All mode
     check<O.Paths<{'prop': {a: 1}[]}, [], 'all'>, ['prop'] | ['prop', number] | ['prop', number, 'a'], Test.Pass>(),
     check<O.Paths<O_PATHS, [], 'all'>, ['a'] | ['a', 'a'] | ['b'] | ['b', 'a'] | ['b', 'a', 'a'] | ['b', 'b'] | ['c'], Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP, [], 'all', { e: number; } | { f: number; }>, ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'] | ['a', 'b', 'h'] | ['a', 'b', 'h', number] | ['a', 'b', 'h', number, 'r'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'all', { e: number | null; } | { f: number | undefined; }>, ['v'] | ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'] | ['a', 'b', 'h'] | ['a', 'b', 'h', number] | ['a', 'b', 'h', number, 'r'], Test.Pass>(),
     // Required mode
     check<O.Paths<{'prop': {a: 1}[]}, [], 'required'>, ['prop', number, 'a'], Test.Pass>(),
     check<O.Paths<O_PATHS, [], 'required'>, ['a', 'a'] | ['b', 'a', 'a'] | ['b', 'b'] | ['c'], Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP, [], 'required', { e: number; } | { f: number; }>, ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'] | ['a', 'b', 'h', number, 'r'], Test.Pass>(),
-    check<O.Paths<O_PATHS_DEEP, [], 'required', { e: number; } | { f: number; }, string>, ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'required', { e: number | null; } | { f: number | undefined; }>, ['v'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'] | ['a', 'b', 'h', number, 'r'], Test.Pass>(),
+    check<O.Paths<O_PATHS_DEEP, [], 'required', { e: number | null; } | { f: number | undefined; }, string>, ['v'] | ['a', 'b', 'c'] | ['a', 'b', 'd'] | ['a', 'b', 'g'], Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## 🎁 Pull Request

* [x] Used a clear / meaningful title for this pull request
* [x] Tested the changes in your own code (on your projects)
* [x] Added / Edited tests to reflect changes (`tests` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

#### Fixes
This adds 2 features to `O.Paths`:
1. Add the ability to "break early" on custom types to avoid stack errors due to circular references in external types (such as `Moment`
1. Add the ability to actually get all the paths in an interface, and not the currently compressed version.
1. Add the ability to get the compact paths, but in a `required` mode. This will help avoid calling `List.Required` which utilizes a lot of computing power for TS :-(
1. Added an option to exclude some key types. This can help reduce the keys used to string only, which makes the output usable by the `String.Join` type

Please see the added tests for examples

#### Why have you made changes?
Having external types in my interface that contain circular dependencies (such as `Moment`) causes TS to break.
In addition, I wanted to create a string type that contains all the available paths in a type.

#### What changes have you made?
* Changed `O.Paths` to accept 3 more optional parameters

#### What tests have you updated?
* tested this in `tests/Object.ts`

#### Is there any breaking changes?
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [x] No,  I added to the existing tests
* [ ] I don't know

#### Anything else worth mentioning?
@millsp your CR and thoughts will be much appreciated :-)