### PR TITLE
fix #242 Infering an F.Curry type as it's "full" signature results in…

### DIFF
--- a/sources/Any/KnownKeys.ts
+++ b/sources/Any/KnownKeys.ts
@@ -13,6 +13,7 @@ export type KnownKeys<O extends object> = {
     string extends K ? never :
     number extends K ? never :
     K
-} extends {
-    [K in keyof O]: infer U
-} ? U & Keys<O> : never;
+} extends infer R ?
+    R extends {
+        [K in keyof O]: infer U
+    } ? U & Keys<O> : never : never;

--- a/sources/Function/Curry.ts
+++ b/sources/Function/Curry.ts
@@ -109,13 +109,16 @@ type Gaps<L extends List> = Cast<NonNullableFlat<{
  * declare function curry<Fn extends F.Function>(fn: Fn): F.Curry<Fn>
  * ```
  */
-export type Curry<F extends Function> =
+export type Curry<F extends Function> = {
     <
         P extends Gaps<Parameters<F>>,
         G extends List = GapsOf<P, Parameters<F>>,
         R extends any = Return<F>
-    >(...p: Gaps<Parameters<F>> | P) =>
-        // handles optional parameters
-        RequiredKeys<G> extends never
+        >(...p: Gaps<Parameters<F>> | P):
+    // handles optional parameters
+    RequiredKeys<G> extends never
         ? R
         : Curry<(...p: G) => R>
+    (...p: Parameters<F>): Return<F>
+}
+

--- a/tests/Function.ts
+++ b/tests/Function.ts
@@ -81,6 +81,17 @@ const test02: boolean = curried(__, 26)(__, true, __)('Jane', 'JJ') // boolean
 const test03: boolean = curried('Jane', 26, true) // boolean
 const test04: boolean = curried('Jane', 26, true, 'JJ') // boolean
 
+// @ts-ignore
+const sorter = (a: string, b: string) => 1;
+const curriedSorter = curry(sorter)
+
+const sort = <T>(fn: (a: T, b: T) => number, list: T[]): T[] => {
+    list.sort(fn)
+    return list
+}
+const curriedSort = curry(sort)
+const test041: string[] = curriedSort(curriedSorter)(['a', 'b'])
+
 // ---------------------------------------------------------------------------------------
 // EXACT
 


### PR DESCRIPTION
… unexpected behavior

## 🎁 Pull Request

* [x ] Used a clear / meaningful title for this pull request
* [x] Tested the changes in your own code (on your projects)
* [x] Added / Edited tests to reflect changes (`tests` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

#### Fixes
 #242

#### Why have you made changes?
To support the ramada type defenitions

#### What changes have you made?
Added to F.Curry an overload of the complete signature of the curried function 

#### What tests have you updated?
* tested this in `tests/Funcction.ts`
* 
#### Is there any breaking changes?
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [x] No,  I added to the existing tests
* [ ] I don't know
