### PR TITLE
PR: Fix Autopath and Path for primitive types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [9.7.0](https://github.com/millsp/ts-toolbelt/compare/v9.5.1...v9.7.0) (2021-09-24)
+
+
+### Features
+
+* **paths:** parameter for AutoPath delimiter ([6d5bbdc](https://github.com/millsp/ts-toolbelt/commit/6d5bbdc834ce15dd3339d101c828457b1a34cce4))
+
+
+### Bug Fixes
+
+* **autopath:** allow for current path extraction ([218da8d](https://github.com/millsp/ts-toolbelt/commit/218da8d26b7d0c91eedf2897446846ded13abb7c))
+* **f.autopath:** distribute ([29eddd9](https://github.com/millsp/ts-toolbelt/commit/29eddd99c6826696941c50681ce4858243786110))
+* **f.autopath:** do not show primitive props ([1ad2638](https://github.com/millsp/ts-toolbelt/commit/1ad26389aa6a9a795d19d90d2724c73ae2bd51d9))
+* **f.autopath:** no primitve paths ([2bdb477](https://github.com/millsp/ts-toolbelt/commit/2bdb4778325288154c8f71c0a5ae4a1b7e2b217f))
+* **f.narrow:** fix variance and array inference ([4c7618d](https://github.com/millsp/ts-toolbelt/commit/4c7618d77b07d6b8c6dfd5087aa85a073bf57db3))
+* **f.narrow:** higher order function support ([dad05ee](https://github.com/millsp/ts-toolbelt/commit/dad05eec6e6710ea4f63063658a3dee4d9c0ca28))
+* **f.narrow:** preserve fns and better display ([a0d62d8](https://github.com/millsp/ts-toolbelt/commit/a0d62d8cfcd28eab7132c225ba187556ca749b4d))
+* **f.narrow:** preserve functions ([c34f1b9](https://github.com/millsp/ts-toolbelt/commit/c34f1b95d0e0855203104eb696cfcb8221a65374))
+* **f.narrow:** revert variance fixes ([12e014a](https://github.com/millsp/ts-toolbelt/commit/12e014a3f3d34047a3722486a73493f857a3697a))
+* **f.narrow:** variance ([866ecd7](https://github.com/millsp/ts-toolbelt/commit/866ecd76744fc38244d85e7ef7b4bb90105cf7eb))
+* **fn:** allow for curried in compose ([2bc5604](https://github.com/millsp/ts-toolbelt/commit/2bc560446916b423977c25e396b4f1f310b6c03f))
+* **o.paths:** dive within arrays and deeper ([626beb6](https://github.com/millsp/ts-toolbelt/commit/626beb61b3100c5e4fd699c946e0e2fed7e24cb6))
+* **path:** avoid methods on primitive types ([389d5f9](https://github.com/millsp/ts-toolbelt/commit/389d5f9ca089cb3e880751a0ca9da45034f5059b))
+
+
+### Others
+
+* **autopath:** add test cases for different types ([3971791](https://github.com/millsp/ts-toolbelt/commit/39717914732cb016f378f279e416f30aca3bcc33))
+* cleanup ([6f23f2e](https://github.com/millsp/ts-toolbelt/commit/6f23f2ec79145a0545eb45d15d50d0363a119b12))
+* **list:** more flexible keys ([d9415b2](https://github.com/millsp/ts-toolbelt/commit/d9415b2f85633c7c74a815c9909899114faf530c))
+* **o.p:** re-implement ([0f44362](https://github.com/millsp/ts-toolbelt/commit/0f443626dc3b114b6784d2053510a1e0c2f7f839))
+* **path:** add test cases for different types ([ccd8072](https://github.com/millsp/ts-toolbelt/commit/ccd80726767f4fb60653de8c13a3435f44bad85b))
+* **release:** 9.5.10 ([1f3928a](https://github.com/millsp/ts-toolbelt/commit/1f3928a70ff2a7e903a5398b53295c9c9997b42c))
+* **release:** 9.5.11 ([bde9210](https://github.com/millsp/ts-toolbelt/commit/bde9210d0a361ddb1e03920a0c2bd42dad17ee30))
+* **release:** 9.5.12 ([80579e1](https://github.com/millsp/ts-toolbelt/commit/80579e1eaa17b2d1c61bd7881d0ea6ff94753141))
+* **release:** 9.5.13 ([277a6e2](https://github.com/millsp/ts-toolbelt/commit/277a6e2ac5ca8be2bbcd7593d987aaac3ea9bb75))
+* **release:** 9.5.2 ([ec4a953](https://github.com/millsp/ts-toolbelt/commit/ec4a953cabe6c4d704c0dca5f37d1dc630de047b))
+* **release:** 9.5.3 ([0836f6e](https://github.com/millsp/ts-toolbelt/commit/0836f6e8187287a0c86f249e4e552d68a44e4f60))
+* **release:** 9.5.4 ([855855e](https://github.com/millsp/ts-toolbelt/commit/855855e520ed4a04059f9d61884d2045dd0d751b))
+* **release:** 9.5.5 ([e28bddf](https://github.com/millsp/ts-toolbelt/commit/e28bddf33066850a764e2ba344883ff84da561b9))
+* **release:** 9.5.6 ([b8e0d0a](https://github.com/millsp/ts-toolbelt/commit/b8e0d0a83228baf666e00f4fdb0d99ca936c133f))
+* **release:** 9.5.7 ([5646455](https://github.com/millsp/ts-toolbelt/commit/564645547862c7d698f4a03b15ccb7a5ffb5fc29))
+* **release:** 9.5.8 ([bceb8be](https://github.com/millsp/ts-toolbelt/commit/bceb8be67701f9c7aba9608aed851567e8118ca5))
+* **release:** 9.5.9 ([533a6ac](https://github.com/millsp/ts-toolbelt/commit/533a6ac0f7b713933c94f0962166c7a0245b055e))
+* **release:** 9.6.0 ([319e551](https://github.com/millsp/ts-toolbelt/commit/319e55123b9571d49f34eca3e5926e41ca73e0f3))
+* **release:** 9.6.0 ([5e6d008](https://github.com/millsp/ts-toolbelt/commit/5e6d008888c1705e41bf752b3a308323a5c563fe))
+* **string:** instantiation limiters ([9a678d8](https://github.com/millsp/ts-toolbelt/commit/9a678d8a400c97436d428dad05405abb154af958))
+* **update:** remove dirty code ([9d0ff64](https://github.com/millsp/ts-toolbelt/commit/9d0ff6441518c2c9a01cea7726c08acd19eb37d9))
+
 ## [9.6.0](https://github.com/millsp/ts-toolbelt/compare/v9.5.1...v9.6.0) (2021-03-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-toolbelt",
-  "version": "9.6.0",
+  "version": "9.7.0",
   "description": "TypeScript's largest utility library",
   "keywords": [
     "safe",

--- a/sources/Function/AutoPath.ts
+++ b/sources/Function/AutoPath.ts
@@ -25,7 +25,7 @@ type KeyToIndex<K extends Key, SP extends List<Index>> =
  */
 type MetaPath<O, D extends string, SP extends List<Index> = [], P extends List<Index> = []> = {
   [K in keyof O]:
-    | MetaPath<O[K], D, Tail<SP>, [...P, KeyToIndex<K, SP>]>
+    | Exclude<MetaPath<O[K], D, Tail<SP>, [...P, KeyToIndex<K, SP>]>, string>
     | Join<[...P, KeyToIndex<K, SP>], D>;
 };
 
@@ -45,6 +45,14 @@ type NextPath<OP> =
   Select<UnionOf<Exclude<OP, string> & {}>, string>;
 
 /**
+ *  @ignore
+ */
+type CurrentPath<OP> =
+  // Uses the reversed logic of NextPath to extract the
+  // current path from the meta paths
+  Select<Exclude<OP, object>, string>;
+
+/**
  * @ignore
  */
 type ExecPath<A, SP extends List<Index>, Delimiter extends string> =
@@ -56,7 +64,9 @@ type ExecPath<A, SP extends List<Index>, Delimiter extends string> =
  * @ignore
  */
 type HintPath<A, P extends string, SP extends List<Index>, Exec extends string, D extends string> = [Exec] extends [never] // if has not found paths
+? CurrentPath<Path<MetaPath<A, D, SP>, SP>> extends never // no current path
   ? ExecPath<A, Pop<SP>, D> // display previous paths
+  : CurrentPath<Path<MetaPath<A, D, SP>, SP>> // display current path
   : Exec | P; // display current + next
 
 /**

--- a/sources/Object/Path.ts
+++ b/sources/Object/Path.ts
@@ -8,12 +8,15 @@ import {Pos} from '../Iteration/Pos'
 import {List} from '../List/List'
 import {Length} from '../List/Length'
 import {At} from '../Any/At'
+import {Primitive} from '../Misc/Primitive'
+
+type _ExcludePrimitiveKeys<O> = O extends Primitive ? Omit<O, keyof O> : O;
 
 /**
  * @ignore
  */
 type _Path<O, P extends List<Key>,  I extends Iteration = IterationOf<0>> = {
-    0: _Path<At<O, P[Pos<I>]>, P, Next<I>>
+    0: _Path<At<_ExcludePrimitiveKeys<O>, P[Pos<I>]>, P, Next<I>>
     1: O
 }[Extends<Pos<I>, Length<P>>]
 
@@ -27,6 +30,6 @@ type _Path<O, P extends List<Key>,  I extends Iteration = IterationOf<0>> = {
  * ```
  */
 export type Path<O extends any, P extends List<Key>> =
-    _Path<O & {}, P> extends infer X
+    _Path<O, P> extends infer X
     ? Cast<X, any>
     : never

--- a/tests/Function.ts
+++ b/tests/Function.ts
@@ -114,6 +114,11 @@ type O_AUTOPATH = {
         };
         b: O_AUTOPATH[];
     };
+    c: boolean[]
+    d: string;
+    e: number;
+    f: () => {};
+    g?: 1;
 };
 
 checks([
@@ -121,10 +126,24 @@ checks([
     check<F.AutoPath<O_AUTOPATH, 'a'>, 'a' | 'a.a', Test.Pass>(),
     check<F.AutoPath<O_AUTOPATH, 'a.'>, 'a.a', Test.Pass>(),
     check<F.AutoPath<O_AUTOPATH, 'b.'>, 'b.b' | 'b.a', Test.Pass>(),
-    check<F.AutoPath<O_AUTOPATH, 'b.b.0'>, 'b.b.0' | 'b.b.0.b' | 'b.b.0.a', Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'b.b.0'>, 'b.b.0' | 'b.b.0.a' | 'b.b.0.b' | 'b.b.0.c' | 'b.b.0.d' | 'b.b.0.e' | 'b.b.0.f' | 'b.b.0.g', Test.Pass>(),
     check<F.AutoPath<O_AUTOPATH, 'b.b.0.a'>, 'b.b.0.a' | 'b.b.0.a.a', Test.Pass>(),
     check<F.AutoPath<O_AUTOPATH, 'b.b.0.a'>, 'b.b.0.a' | 'b.b.x.a.a', Test.Fail>(),
     check<F.AutoPath<O_AUTOPATH, 'b.b.0.a'>, 'b.b.0.a' | 'b.b.a.a', Test.Fail>(),
+    check<F.AutoPath<O_AUTOPATH, 'c'>, 'c', Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'c.0'>, 'c.0', Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'c.0.'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'c.0.valueOf'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'd'>, 'd', Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'd.'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'd.toUpperCase'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'd.toUpperCase.call'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'e'>, 'e', Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'e.toFixed'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'f'>, 'f', Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'f.'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'f.call'>, never, Test.Pass>(),
+    check<F.AutoPath<O_AUTOPATH, 'g'>, 'g', Test.Pass>(),
     check<F.AutoPath<GlobalEventHandlersEventMap, 'cancel.isTrusted.'>, never, Test.Pass>(),
 ])
 

--- a/tests/Object.ts
+++ b/tests/Object.ts
@@ -1013,6 +1013,13 @@ checks([
     check<O.Path<O, ['g', 'x', 'g']>, undefined, Test.Pass>(),
     // check<O.Path<O, []>, undefined, Test.Pass>(),
     check<O.Path<O, ['d']>, 'string0' | undefined, Test.Pass>(),
+    check<O.Path<O, ['']>, undefined, Test.Pass>(),
+    check<O.Path<O, ['a', 'toUpperCase']>, undefined, Test.Pass>(),
+    check<O.Path<O, ['b', 'toFixed']>, undefined, Test.Pass>(),
+    check<O.Path<O, ['h']>, 1 | undefined, Test.Pass>(),
+    // eslint-disable-next-line func-call-spacing
+    check<O.Path<O, ['x']>, () => 1, Test.Pass>(),
+    check<O.Path<O, ['x', 'call']>, undefined, Test.Pass>(),
 ])
 
 type O_PATH_U = {


### PR DESCRIPTION
## 🎁 Pull Request

<!-- Fill the following checklist. -->
* [x] Used a clear / meaningful title for this pull request
* [x] Tested the changes in your own code (on your projects)
* [x] Added / Edited tests to reflect changes (`tests` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

<!-- Complete the following parts. -->

#### Fixes
<!-- List the issues that this fixes. -->
#246
#228

#### Why have you made changes?
<!-- A clear & concise explanation. -->
To fix the above mentioned issues. Autopath currently does not work for primitive types since they don't have a "next path".

#### What changes have you made?
* Added a new type CurrentPath in Autopath to retrieve the value of the current path if there's no next path, using the inverse logic for NextPath
* Added a filter in Path to exclude methods from primitive types, since Path currently return their types (ex: `a.someStr.toUpperCase` returns `() => string`). This way Path and Autopath have a more consistent behavior when working together.

#### What tests have you updated?
* tested primitive types, array indexes and functions in `tests/Function.ts`
* tested paths to primitive methods in `tests/Object.ts`

#### Is there any breaking changes?
<!-- Fill the following checklist. -->
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [X] No,  I added to the existing tests
* [ ] I don't know
