### PR TITLE
fix: `Join` with readonly arrays

### DIFF
--- a/sources/String/Join.ts
+++ b/sources/String/Join.ts
@@ -6,9 +6,9 @@ import {Cast} from '../Any/Cast'
  * @hidden
  */
 type _Join<T extends List, D extends string> =
-    T extends [] ? '' :
-    T extends [Literal] ? `${T[0]}` :
-    T extends [Literal, ...infer R] ? `${T[0]}${D}${_Join<R, D>}` :
+    T extends readonly [] ? '' :
+    T extends readonly [Literal] ? `${T[0]}` :
+    T extends readonly [Literal, ...infer R] ? `${T[0]}${D}${_Join<R, D>}` :
     string
 
 /**

--- a/tests/String.ts
+++ b/tests/String.ts
@@ -22,6 +22,7 @@ checks([
 
 checks([
     check<S.Join<S.Split<S, ''>>, S, Test.Pass>(),
+    check<S.Join<Readonly<S.Split<S, ''>>>, S, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## 🎁 Pull Request

<!-- Fill the following checklist. -->
* [X] Used a clear / meaningful title for this pull request
* [X] Tested the changes in your own code (on your projects)
* [X] Added / Edited tests to reflect changes (`tests` folder)
* [X] Have read the **Contributing** part of the **Readme**
* [X] Passed `npm test`

<!-- Complete the following parts. -->

#### Fixes
<!-- List the issues that this fixes. -->
fixes #258 
#### Why have you made changes?
<!-- A clear & concise explanation. -->
`Join` didn't work with readonly arrays
#### What changes have you made?
* added `readonly` keyword to arrays checked by the `_Join` conditional type
#### What tests have you updated?
* `JOIN` in `tests/String.ts`

#### Is there any breaking changes?
<!-- Fill the following checklist. -->
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [X] No,  I added to the existing tests
* [ ] I don't know

#### Anything else worth mentioning?
<!-- Please help with the PR process. -->
<!-- Leave any extra useful information. -->
<!-- Or mention someone who is concerned. -->
