### PR TITLE
feat: add ESM export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [9.7.0](https://github.com/millsp/ts-toolbelt/compare/v9.5.1...v9.7.0) (2022-05-30)
+
+
+### Features
+
+* export module ([a474bdb](https://github.com/millsp/ts-toolbelt/commit/a474bdb15274740ab662bedfcf05ba2c7af03d9a))
+* **paths:** parameter for AutoPath delimiter ([6d5bbdc](https://github.com/millsp/ts-toolbelt/commit/6d5bbdc834ce15dd3339d101c828457b1a34cce4))
+
+
+### Bug Fixes
+
+* **f.autopath:** distribute ([29eddd9](https://github.com/millsp/ts-toolbelt/commit/29eddd99c6826696941c50681ce4858243786110))
+* **f.autopath:** do not show primitive props ([1ad2638](https://github.com/millsp/ts-toolbelt/commit/1ad26389aa6a9a795d19d90d2724c73ae2bd51d9))
+* **f.autopath:** no primitve paths ([2bdb477](https://github.com/millsp/ts-toolbelt/commit/2bdb4778325288154c8f71c0a5ae4a1b7e2b217f))
+* **f.narrow:** fix variance and array inference ([4c7618d](https://github.com/millsp/ts-toolbelt/commit/4c7618d77b07d6b8c6dfd5087aa85a073bf57db3))
+* **f.narrow:** higher order function support ([dad05ee](https://github.com/millsp/ts-toolbelt/commit/dad05eec6e6710ea4f63063658a3dee4d9c0ca28))
+* **f.narrow:** preserve fns and better display ([a0d62d8](https://github.com/millsp/ts-toolbelt/commit/a0d62d8cfcd28eab7132c225ba187556ca749b4d))
+* **f.narrow:** preserve functions ([c34f1b9](https://github.com/millsp/ts-toolbelt/commit/c34f1b95d0e0855203104eb696cfcb8221a65374))
+* **f.narrow:** revert variance fixes ([12e014a](https://github.com/millsp/ts-toolbelt/commit/12e014a3f3d34047a3722486a73493f857a3697a))
+* **f.narrow:** variance ([866ecd7](https://github.com/millsp/ts-toolbelt/commit/866ecd76744fc38244d85e7ef7b4bb90105cf7eb))
+* **fn:** allow for curried in compose ([2bc5604](https://github.com/millsp/ts-toolbelt/commit/2bc560446916b423977c25e396b4f1f310b6c03f))
+* **o.paths:** dive within arrays and deeper ([626beb6](https://github.com/millsp/ts-toolbelt/commit/626beb61b3100c5e4fd699c946e0e2fed7e24cb6))
+
+
+### Others
+
+* cleanup ([6f23f2e](https://github.com/millsp/ts-toolbelt/commit/6f23f2ec79145a0545eb45d15d50d0363a119b12))
+* **list:** more flexible keys ([d9415b2](https://github.com/millsp/ts-toolbelt/commit/d9415b2f85633c7c74a815c9909899114faf530c))
+* **o.p:** re-implement ([0f44362](https://github.com/millsp/ts-toolbelt/commit/0f443626dc3b114b6784d2053510a1e0c2f7f839))
+* **release:** 9.5.10 ([1f3928a](https://github.com/millsp/ts-toolbelt/commit/1f3928a70ff2a7e903a5398b53295c9c9997b42c))
+* **release:** 9.5.11 ([bde9210](https://github.com/millsp/ts-toolbelt/commit/bde9210d0a361ddb1e03920a0c2bd42dad17ee30))
+* **release:** 9.5.12 ([80579e1](https://github.com/millsp/ts-toolbelt/commit/80579e1eaa17b2d1c61bd7881d0ea6ff94753141))
+* **release:** 9.5.13 ([277a6e2](https://github.com/millsp/ts-toolbelt/commit/277a6e2ac5ca8be2bbcd7593d987aaac3ea9bb75))
+* **release:** 9.5.2 ([ec4a953](https://github.com/millsp/ts-toolbelt/commit/ec4a953cabe6c4d704c0dca5f37d1dc630de047b))
+* **release:** 9.5.3 ([0836f6e](https://github.com/millsp/ts-toolbelt/commit/0836f6e8187287a0c86f249e4e552d68a44e4f60))
+* **release:** 9.5.4 ([855855e](https://github.com/millsp/ts-toolbelt/commit/855855e520ed4a04059f9d61884d2045dd0d751b))
+* **release:** 9.5.5 ([e28bddf](https://github.com/millsp/ts-toolbelt/commit/e28bddf33066850a764e2ba344883ff84da561b9))
+* **release:** 9.5.6 ([b8e0d0a](https://github.com/millsp/ts-toolbelt/commit/b8e0d0a83228baf666e00f4fdb0d99ca936c133f))
+* **release:** 9.5.7 ([5646455](https://github.com/millsp/ts-toolbelt/commit/564645547862c7d698f4a03b15ccb7a5ffb5fc29))
+* **release:** 9.5.8 ([bceb8be](https://github.com/millsp/ts-toolbelt/commit/bceb8be67701f9c7aba9608aed851567e8118ca5))
+* **release:** 9.5.9 ([533a6ac](https://github.com/millsp/ts-toolbelt/commit/533a6ac0f7b713933c94f0962166c7a0245b055e))
+* **release:** 9.6.0 ([319e551](https://github.com/millsp/ts-toolbelt/commit/319e55123b9571d49f34eca3e5926e41ca73e0f3))
+* **release:** 9.6.0 ([5e6d008](https://github.com/millsp/ts-toolbelt/commit/5e6d008888c1705e41bf752b3a308323a5c563fe))
+* **string:** instantiation limiters ([9a678d8](https://github.com/millsp/ts-toolbelt/commit/9a678d8a400c97436d428dad05405abb154af958))
+* **update:** remove dirty code ([9d0ff64](https://github.com/millsp/ts-toolbelt/commit/9d0ff6441518c2c9a01cea7726c08acd19eb37d9))
+
 ## [9.6.0](https://github.com/millsp/ts-toolbelt/compare/v9.5.1...v9.6.0) (2021-03-10)
 
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "name": "Pierre-Antoine Mills",
     "url": "https://github.com/millsp"
   },
+  "module": "index.mjs",
   "main": "out/index.js",
   "types": "out/index.d.ts",
   "files": [
-    "out"
+    "out",
+    "esm.mjs"
   ],
   "scripts": {
     "build:clean": "bash scripts/build/clean.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-toolbelt",
-  "version": "9.6.0",
+  "version": "9.7.0",
   "description": "TypeScript's largest utility library",
   "keywords": [
     "safe",
@@ -19,8 +19,8 @@
     "name": "Pierre-Antoine Mills",
     "url": "https://github.com/millsp"
   },
-  "module": "index.mjs",
   "main": "out/index.js",
+  "module": "index.mjs",
   "types": "out/index.d.ts",
   "files": [
     "out",


### PR DESCRIPTION
## 🎁 Pull Request

<!-- Fill the following checklist. -->
* [X] Used a clear / meaningful title for this pull request
* [X] Tested the changes in your own code (on your projects)
* [ ] Added / Edited tests to reflect changes (`tests` folder)
* [X] Have read the **Contributing** part of the **Readme**
* [X] Passed `npm test`

<!-- Complete the following parts. -->

#### Fixes
<!-- List the issues that this fixes. -->
Right now, if you use vite you will see this error:
````
ts-toolbelt doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.
````

See https://github.com/millsp/ts-toolbelt/issues/283

#### Why have you made changes?
<!-- A clear & concise explanation. -->

The package is missing an ESM export and this PR will add an empty ESM export so vite does not complain anymore

#### What changes have you made?
* changed this to achieve this
* changed that to achieve this
* ...

#### What tests have you updated?
* tested this in `tests/...`
* tested that in `tests/...`
* ...

#### Is there any breaking changes?
<!-- Fill the following checklist. -->
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [ ] No,  I added to the existing tests
* [ ] I don't know

#### Anything else worth mentioning?
<!-- Please help with the PR process. -->
<!-- Leave any extra useful information. -->
<!-- Or mention someone who is concerned. -->
