### PR TITLE
feat: add enum value to union and some utils

### DIFF
--- a/sources/List/IndexOf.ts
+++ b/sources/List/IndexOf.ts
@@ -1,0 +1,14 @@
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+  ? 1
+  : 2
+  ? true
+  : false;
+
+export type IndexOf<T extends any[], U, Pass extends any[] = []> = T extends [
+  infer F,
+  ...infer Rest
+]
+  ? Equal<F, U> extends true
+    ? Pass["length"]
+    : IndexOf<Rest, U, [...Pass, F]>
+  : -1;

--- a/sources/List/_api.ts
+++ b/sources/List/_api.ts
@@ -1,73 +1,74 @@
-/** @ignore *//** */
+/** @ignore */ /** */
 
-export {Append} from './Append'
-export {Assign} from './Assign'
-export {AtLeast} from './AtLeast'
-export {Compulsory} from './Compulsory'
-export {CompulsoryKeys} from './CompulsoryKeys'
-export {Concat} from './Concat'
-export {Diff} from './Diff'
-export {Drop} from './Drop'
-export {Either} from './Either'
-export {Exclude} from './Exclude'
-export {ExcludeKeys} from './ExcludeKeys'
-export {Extract} from './Extract'
-export {Filter} from './Filter'
-export {FilterKeys} from './FilterKeys'
-export {Flatten} from './Flatten'
-export {Group} from './Group'
-export {Has} from './Has'
-export {HasPath} from './HasPath'
-export {Head} from './Head'
-export {Includes} from './Includes'
-export {Intersect} from './Intersect'
-export {IntersectKeys} from './IntersectKeys'
-export {KeySet} from './KeySet'
-export {Last} from './Last'
-export {LastKey} from './LastKey'
-export {Length} from './Length'
-export {List} from './List'
-export {Longest} from './Longest'
-export {Merge} from './Merge'
-export {MergeAll} from './MergeAll'
-export {Modify} from './Modify'
-export {NonNullable} from './NonNullable'
-export {NonNullableKeys} from './NonNullableKeys'
-export {Nullable} from './Nullable'
-export {NullableKeys} from './NullableKeys'
-export {ObjectOf} from './ObjectOf'
-export {Omit} from './Omit'
-export {Optional} from './Optional'
-export {OptionalKeys} from './OptionalKeys'
-export {Overwrite} from './Overwrite'
-export {Partial} from './Partial'
-export {Patch} from './Patch'
-export {PatchAll} from './PatchAll'
-export {Path} from './Path'
-export {Paths} from './Paths'
-export {Pick} from './Pick'
-export {Pop} from './Pop'
-export {Prepend} from './Prepend'
-export {Readonly} from './Readonly'
-export {ReadonlyKeys} from './ReadonlyKeys'
-export {Remove} from './Remove'
-export {Repeat} from './Repeat'
-export {Replace} from './Replace'
-export {Required} from './Required'
-export {RequiredKeys} from './RequiredKeys'
-export {Reverse} from './Reverse'
-export {Select} from './Select'
-export {SelectKeys} from './SelectKeys'
-export {Shortest} from './Shortest'
-export {Tail} from './Tail'
-export {Take} from './Take'
-export {Undefinable} from './Undefinable'
-export {UndefinableKeys} from './UndefinableKeys'
-export {Unionize} from './Unionize'
-export {UnionOf} from './UnionOf'
-export {UnNest} from './UnNest'
-export {Update} from './Update'
-export {Writable} from './Writable'
-export {WritableKeys} from './WritableKeys'
-export {Zip} from './Zip'
-export {ZipObj} from './ZipObj'
+export { Append } from "./Append";
+export { Assign } from "./Assign";
+export { AtLeast } from "./AtLeast";
+export { Compulsory } from "./Compulsory";
+export { CompulsoryKeys } from "./CompulsoryKeys";
+export { Concat } from "./Concat";
+export { Diff } from "./Diff";
+export { Drop } from "./Drop";
+export { Either } from "./Either";
+export { Exclude } from "./Exclude";
+export { ExcludeKeys } from "./ExcludeKeys";
+export { Extract } from "./Extract";
+export { Filter } from "./Filter";
+export { FilterKeys } from "./FilterKeys";
+export { Flatten } from "./Flatten";
+export { Group } from "./Group";
+export { Has } from "./Has";
+export { HasPath } from "./HasPath";
+export { Head } from "./Head";
+export { Includes } from "./Includes";
+export { IndexOf } from "./IndexOf";
+export { Intersect } from "./Intersect";
+export { IntersectKeys } from "./IntersectKeys";
+export { KeySet } from "./KeySet";
+export { Last } from "./Last";
+export { LastKey } from "./LastKey";
+export { Length } from "./Length";
+export { List } from "./List";
+export { Longest } from "./Longest";
+export { Merge } from "./Merge";
+export { MergeAll } from "./MergeAll";
+export { Modify } from "./Modify";
+export { NonNullable } from "./NonNullable";
+export { NonNullableKeys } from "./NonNullableKeys";
+export { Nullable } from "./Nullable";
+export { NullableKeys } from "./NullableKeys";
+export { ObjectOf } from "./ObjectOf";
+export { Omit } from "./Omit";
+export { Optional } from "./Optional";
+export { OptionalKeys } from "./OptionalKeys";
+export { Overwrite } from "./Overwrite";
+export { Partial } from "./Partial";
+export { Patch } from "./Patch";
+export { PatchAll } from "./PatchAll";
+export { Path } from "./Path";
+export { Paths } from "./Paths";
+export { Pick } from "./Pick";
+export { Pop } from "./Pop";
+export { Prepend } from "./Prepend";
+export { Readonly } from "./Readonly";
+export { ReadonlyKeys } from "./ReadonlyKeys";
+export { Remove } from "./Remove";
+export { Repeat } from "./Repeat";
+export { Replace } from "./Replace";
+export { Required } from "./Required";
+export { RequiredKeys } from "./RequiredKeys";
+export { Reverse } from "./Reverse";
+export { Select } from "./Select";
+export { SelectKeys } from "./SelectKeys";
+export { Shortest } from "./Shortest";
+export { Tail } from "./Tail";
+export { Take } from "./Take";
+export { Undefinable } from "./Undefinable";
+export { UndefinableKeys } from "./UndefinableKeys";
+export { Unionize } from "./Unionize";
+export { UnionOf } from "./UnionOf";
+export { UnNest } from "./UnNest";
+export { Update } from "./Update";
+export { Writable } from "./Writable";
+export { WritableKeys } from "./WritableKeys";
+export { Zip } from "./Zip";
+export { ZipObj } from "./ZipObj";

--- a/sources/String/StringNumToNum.ts
+++ b/sources/String/StringNumToNum.ts
@@ -1,0 +1,85 @@
+import { IndexOf } from "../List/IndexOf";
+import { Lower } from "../Number/Lower";
+
+export type Numbers = [
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "11",
+  "12",
+  "13",
+  "14",
+  "15",
+  "16",
+  "17",
+  "18",
+  "19",
+  "20",
+  "21",
+  "22",
+  "23",
+  "24",
+  "25",
+  "26",
+  "27",
+  "28",
+  "29",
+  "30",
+  "31",
+  "32",
+  "33",
+  "34",
+  "35",
+  "36",
+  "37",
+  "38",
+  "39",
+  "40",
+  "41",
+  "42",
+  "43",
+  "44",
+  "45",
+  "46",
+  "47",
+  "48",
+  "49",
+  "50",
+  "51",
+  "52",
+  "53",
+  "54",
+  "55",
+  "56",
+  "57",
+  "58",
+  "59",
+  "60",
+  "61",
+  "62",
+  "63"
+];
+
+/**
+ * string type number to number
+ * @param S
+ * @param K
+ */
+export type StringNumToNum<T extends string> = IndexOf<
+  Numbers,
+  T
+> extends infer N
+  ? N extends number
+    ? Lower<N, 63> extends 0 | 1
+      ? N
+      : never
+    : never
+  : never;

--- a/sources/String/_api.ts
+++ b/sources/String/_api.ts
@@ -1,7 +1,8 @@
-/** @ignore *//** */
+/** @ignore */ /** */
 
-export {At} from './At'
-export {Join} from './Join'
-export {Length} from './Length'
-export {Replace} from './Replace'
-export {Split} from './Split'
+export { At } from "./At";
+export { Join } from "./Join";
+export { Length } from "./Length";
+export { Replace } from "./Replace";
+export { Split } from "./Split";
+export { StringNumToNum } from "./StringNumToNum";

--- a/sources/Union/EnumValue.ts
+++ b/sources/Union/EnumValue.ts
@@ -1,0 +1,13 @@
+import { StringNumToNum } from "../String/StringNumToNum";
+
+export type EnumValue<T> = T extends infer TUn
+  ? TUn extends string
+    ? `${TUn}`
+    : TUn extends number
+    ? `${TUn}` extends infer TunItem
+      ? TunItem extends string
+        ? StringNumToNum<TunItem>
+        : never
+      : never
+    : never
+  : never;

--- a/sources/Union/_api.ts
+++ b/sources/Union/_api.ts
@@ -1,17 +1,18 @@
-/** @ignore *//** */
+/** @ignore */ /** */
 
-export {Diff} from './Diff'
-export {Exclude} from './Exclude'
-export {Filter} from './Filter'
-export {Has} from './Has'
-export {Intersect} from './Intersect'
-export {IntersectOf} from './IntersectOf'
-export {Last} from './Last'
-export {Merge} from './Merge'
-export {NonNullable} from './NonNullable'
-export {Nullable} from './Nullable'
-export {Pop} from './Pop'
-export {Replace} from './Replace'
-export {Select} from './Select'
-export {Strict} from './Strict'
-export {ListOf} from './ListOf'
+export { Diff } from "./Diff";
+export { EnumValue } from "./EnumValue";
+export { Exclude } from "./Exclude";
+export { Filter } from "./Filter";
+export { Has } from "./Has";
+export { Intersect } from "./Intersect";
+export { IntersectOf } from "./IntersectOf";
+export { Last } from "./Last";
+export { Merge } from "./Merge";
+export { NonNullable } from "./NonNullable";
+export { Nullable } from "./Nullable";
+export { Pop } from "./Pop";
+export { Replace } from "./Replace";
+export { Select } from "./Select";
+export { Strict } from "./Strict";
+export { ListOf } from "./ListOf";

--- a/tests/List.ts
+++ b/tests/List.ts
@@ -1,77 +1,66 @@
-import {Test, T, A} from '../sources'
+import { Test, T, A } from "../sources";
 
-const {checks, check} = Test
+const { checks, check } = Test;
 
 // ///////////////////////////////////////////////////////////////////////////////////////
 // LIST /////////////////////////////////////////////////////////////////////////////////
 
 type T = [
-    1,
-    2,
-    '3' | undefined,
-    'xxxx',
-    {a: 'a'} & {b: 'b'},
-    string | number,
-    number,
-    object,
-    readonly [0, 1, 2?],
-    'xxxx'?
+  1,
+  2,
+  "3" | undefined,
+  "xxxx",
+  { a: "a" } & { b: "b" },
+  string | number,
+  number,
+  object,
+  readonly [0, 1, 2?],
+  "xxxx"?
 ];
 
 type T1 = [
-    1,
-    2,
-    '3',
-    'xxxx',
-    string,
-    number,
-    number & {},
-    object,
-    readonly [0, 1, 2?, 3?],
-    {a: never},
-    'xxxx'?
+  1,
+  2,
+  "3",
+  "xxxx",
+  string,
+  number,
+  number & {},
+  object,
+  readonly [0, 1, 2?, 3?],
+  { a: never },
+  "xxxx"?
 ];
 
 // ---------------------------------------------------------------------------------------
 // APPEND
 
 checks([
-    check<T.Append<[0, 1, 2, 3], 4>, [0, 1, 2, 3, 4], Test.Pass>(),
-    check<T.Append<[0, 1, 2, 3], [4, 5]>, [0, 1, 2, 3, [4, 5]], Test.Pass>(),
-])
+  check<T.Append<[0, 1, 2, 3], 4>, [0, 1, 2, 3, 4], Test.Pass>(),
+  check<T.Append<[0, 1, 2, 3], [4, 5]>, [0, 1, 2, 3, [4, 5]], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // ASSIGN
 
-checks([
-    check<T.Assign<[1], [[2, 1], [3, 2?]]>, [3, 2 | 1], Test.Pass>(),
-])
+checks([check<T.Assign<[1], [[2, 1], [3, 2?]]>, [3, 2 | 1], Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // ATLEAST
 
-type T_ATLEAST = [
-    0,
-    1,
-    2
-] | [
-    3,
-    4,
-    5,
-    6
-];
+type T_ATLEAST = [0, 1, 2] | [3, 4, 5, 6];
 
 type ATLEAST_T_013 =
-    | [0, 1, 2]
-    | [0, 1 | undefined, 2 | undefined]
-    | [0 | undefined, 1, 2 | undefined]
-    | [3, 4 | undefined, 5 | undefined, 6 | undefined]
-    | [3 | undefined, 4, 5 | undefined, 6 | undefined]
-    | [3 | undefined, 4 | undefined, 5 | undefined, 6];
+  | [0, 1, 2]
+  | [0, 1 | undefined, 2 | undefined]
+  | [0 | undefined, 1, 2 | undefined]
+  | [3, 4 | undefined, 5 | undefined, 6 | undefined]
+  | [3 | undefined, 4, 5 | undefined, 6 | undefined]
+  | [3 | undefined, 4 | undefined, 5 | undefined, 6];
 
 checks([
-    check<T.AtLeast<T_ATLEAST, '0' | '1' | '3'>, ATLEAST_T_013, Test.Pass>(),
-])
+  check<T.AtLeast<T_ATLEAST, "0" | "1" | "3">, ATLEAST_T_013, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // COMPULSORY
@@ -87,106 +76,120 @@ checks([
 // CONCAT
 
 checks([
-    check<T.Concat<[1, 2, 3], [4, 5, 6]>, [1, 2, 3, 4, 5, 6], Test.Pass>(),
-    check<T.Concat<['1', '2', '3'], ['4']>, ['1', '2', '3', '4'], Test.Pass>(),
-    check<T.Concat<[1], number[]>, [1, ...number[]], Test.Pass>(),
-])
+  check<T.Concat<[1, 2, 3], [4, 5, 6]>, [1, 2, 3, 4, 5, 6], Test.Pass>(),
+  check<T.Concat<["1", "2", "3"], ["4"]>, ["1", "2", "3", "4"], Test.Pass>(),
+  check<T.Concat<[1], number[]>, [1, ...number[]], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // DIFF
 
 checks([
-    check<T.Diff<[1, 2, 3], [4, 5, 6], 'default'>, [], Test.Pass>(),
-    check<T.Diff<[1, 2, 3], [4, number, 6], 'extends->'>, [1, number, 3], Test.Pass>(),
-    check<T.Diff<[1, 2, 3], [4, 5, 6, 7], 'equals'>, [1, 2, 3, 7], Test.Pass>(),
-])
+  check<T.Diff<[1, 2, 3], [4, 5, 6], "default">, [], Test.Pass>(),
+  check<
+    T.Diff<[1, 2, 3], [4, number, 6], "extends->">,
+    [1, number, 3],
+    Test.Pass
+  >(),
+  check<T.Diff<[1, 2, 3], [4, 5, 6, 7], "equals">, [1, 2, 3, 7], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // DROP
 
 checks([
-    check<T.Drop<[1, 2, 3, 4], 10, '->'>, [], Test.Pass>(),
-    check<T.Drop<[1, 2, 3, 4], 2, '->'>, [3, 4], Test.Pass>(),
-    check<T.Drop<[1, 2, 3, 4], 2, '<-'>, [1, 2], Test.Pass>(),
-])
+  check<T.Drop<[1, 2, 3, 4], 10, "->">, [], Test.Pass>(),
+  check<T.Drop<[1, 2, 3, 4], 2, "->">, [3, 4], Test.Pass>(),
+  check<T.Drop<[1, 2, 3, 4], 2, "<-">, [1, 2], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // EITHER
 
-type T_EITHER = [
-    0,
-    1,
-    2
-];
+type T_EITHER = [0, 1, 2];
 
 type EITHER_T_01 = [0, undefined, 2] | [undefined, 1, 2];
 
-checks([
-    check<T.Either<T_EITHER, '0' | '1'>, EITHER_T_01, Test.Pass>(),
-])
+checks([check<T.Either<T_EITHER, "0" | "1">, EITHER_T_01, Test.Pass>()]);
 
 // -------------------------------------------------------------------------------------
 // EXCLUDE
 
 checks([
-    check<T.Exclude<[1, 2, 3, 4], [0, 0, 0], 'default'>, [4], Test.Pass>(),
-    check<T.Exclude<[1, 2, 3, 4], [1, 0, 0], 'equals'>, [2, 3, 4], Test.Pass>(),
-    check<T.Exclude<[1, 2, 3, 4], [1, string, 3], 'extends->'>, [2, 4], Test.Pass>(),
-    check<T.Exclude<[1, number, 3, 4], [1, 2, 3], 'extends->'>, [number, 4], Test.Pass>(),
-])
+  check<T.Exclude<[1, 2, 3, 4], [0, 0, 0], "default">, [4], Test.Pass>(),
+  check<T.Exclude<[1, 2, 3, 4], [1, 0, 0], "equals">, [2, 3, 4], Test.Pass>(),
+  check<
+    T.Exclude<[1, 2, 3, 4], [1, string, 3], "extends->">,
+    [2, 4],
+    Test.Pass
+  >(),
+  check<
+    T.Exclude<[1, number, 3, 4], [1, 2, 3], "extends->">,
+    [number, 4],
+    Test.Pass
+  >(),
+]);
 
 // -------------------------------------------------------------------------------------
 // EXCLUDEKEYS
 
 checks([
-    check<T.ExcludeKeys<[1, 2, 3, 4], [0, 0, 0], 'default'>, '3', Test.Pass>(),
-    check<T.ExcludeKeys<[1, 2, 3, 4], [1, 0, 0], 'equals'>, '1' | '2' | '3', Test.Pass>(),
-    check<T.ExcludeKeys<[1, 2, 3, 4], [1, string, 3], 'extends->'>, '1' | '3', Test.Pass>(),
-    check<T.ExcludeKeys<[1, number, 3, 4], [1, 2, 3], 'extends->'>, '1' | '3', Test.Pass>(),
-])
+  check<T.ExcludeKeys<[1, 2, 3, 4], [0, 0, 0], "default">, "3", Test.Pass>(),
+  check<
+    T.ExcludeKeys<[1, 2, 3, 4], [1, 0, 0], "equals">,
+    "1" | "2" | "3",
+    Test.Pass
+  >(),
+  check<
+    T.ExcludeKeys<[1, 2, 3, 4], [1, string, 3], "extends->">,
+    "1" | "3",
+    Test.Pass
+  >(),
+  check<
+    T.ExcludeKeys<[1, number, 3, 4], [1, 2, 3], "extends->">,
+    "1" | "3",
+    Test.Pass
+  >(),
+]);
 
 // -------------------------------------------------------------------------------------
 // EXTRACT
 
 checks([
-    check<T.Extract<[1, 2, 3, 4, 5], 1, 3>, [2, 3, 4], Test.Pass>(),
-    check<T.Extract<[1, 2, 3, 4, 5], -1, 13>, [1, 2, 3, 4, 5], Test.Pass>(),
-])
+  check<T.Extract<[1, 2, 3, 4, 5], 1, 3>, [2, 3, 4], Test.Pass>(),
+  check<T.Extract<[1, 2, 3, 4, 5], -1, 13>, [1, 2, 3, 4, 5], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // FILTER
 
 type FILTER_T_NUMBER_EXTENDS = [
-    '3' | undefined,
-    'xxxx',
-    {a: 'a'} & {b: 'b'},
-    string | number,
-    object,
-    readonly [
-        0,
-        1,
-        2?,
-    ],
-    'xxxx' | undefined
+  "3" | undefined,
+  "xxxx",
+  { a: "a" } & { b: "b" },
+  string | number,
+  object,
+  readonly [0, 1, 2?],
+  "xxxx" | undefined
 ];
 
 type FILTER_T_NUMBER_EQUALS = [
-    1,
-    2,
-    '3' | undefined,
-    'xxxx',
-    {a: 'a'} & {b: 'b'},
-    string | number,
-    object,
-    readonly [0, 1, 2?],
-    'xxxx' | undefined
+  1,
+  2,
+  "3" | undefined,
+  "xxxx",
+  { a: "a" } & { b: "b" },
+  string | number,
+  object,
+  readonly [0, 1, 2?],
+  "xxxx" | undefined
 ];
 
 checks([
-    check<T.Filter<T, number, 'default'>, FILTER_T_NUMBER_EXTENDS, Test.Pass>(),
-    check<T.Filter<T, number, 'extends->'>, FILTER_T_NUMBER_EXTENDS, Test.Pass>(),
-    check<T.Filter<T, number, 'equals'>, FILTER_T_NUMBER_EQUALS, Test.Pass>(),
-])
+  check<T.Filter<T, number, "default">, FILTER_T_NUMBER_EXTENDS, Test.Pass>(),
+  check<T.Filter<T, number, "extends->">, FILTER_T_NUMBER_EXTENDS, Test.Pass>(),
+  check<T.Filter<T, number, "equals">, FILTER_T_NUMBER_EQUALS, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // FILTERKEYS
@@ -197,16 +200,18 @@ checks([
 // FLATTEN
 
 type T_FLATTEN = [1, 12, [2, [3, [4, [5, [6, [7, [8, [9, 92?]]]]]]]]];
-type FLATTEN_T = [1, 12, 2, 3, 4, 5, 6, 7, 8, 9, 92] | [1, 12, 2, 3, 4, 5, 6, 7, 8, 9, undefined];
+type FLATTEN_T =
+  | [1, 12, 2, 3, 4, 5, 6, 7, 8, 9, 92]
+  | [1, 12, 2, 3, 4, 5, 6, 7, 8, 9, undefined];
 
 checks([
-    check<T.Flatten<any>, any[], Test.Pass>(),
-    check<T.Flatten<any[]>, any[], Test.Pass>(),
-    check<T.Flatten<T_FLATTEN>, FLATTEN_T, Test.Pass>(),
-    check<T.Flatten<[1, 2, 42]>, [1, 2, 42], Test.Pass>(),
-    check<T.Flatten<[1, 2?]>, [1, undefined] | [1, 2], Test.Pass>(),
-    check<T.Flatten<readonly [1, 2, 42]>, [1, 2, 42], Test.Pass>(),
-])
+  check<T.Flatten<any>, any[], Test.Pass>(),
+  check<T.Flatten<any[]>, any[], Test.Pass>(),
+  check<T.Flatten<T_FLATTEN>, FLATTEN_T, Test.Pass>(),
+  check<T.Flatten<[1, 2, 42]>, [1, 2, 42], Test.Pass>(),
+  check<T.Flatten<[1, 2?]>, [1, undefined] | [1, 2], Test.Pass>(),
+  check<T.Flatten<readonly [1, 2, 42]>, [1, 2, 42], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // GROUP
@@ -218,11 +223,11 @@ type GROUP_T_2 = [[1, 2], [3, 4], [5, 6], [7, 8]];
 type GROUP_T_3 = [[1, 2, 3], [4, 5, 6], [7, 8, undefined]];
 
 checks([
-    check<T.Group<T_GROUP, 1>, GROUP_T_1, Test.Pass>(),
-    check<T.Group<T_GROUP, 2>, GROUP_T_2, Test.Pass>(),
-    check<T.Group<T_GROUP, 3>, GROUP_T_3, Test.Pass>(),
-    check<T.Group<[], 3>, [], Test.Pass>(),
-])
+  check<T.Group<T_GROUP, 1>, GROUP_T_1, Test.Pass>(),
+  check<T.Group<T_GROUP, 2>, GROUP_T_2, Test.Pass>(),
+  check<T.Group<T_GROUP, 3>, GROUP_T_3, Test.Pass>(),
+  check<T.Group<[], 3>, [], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // HAS
@@ -238,10 +243,10 @@ checks([
 // HEAD
 
 checks([
-    check<T.Head<T>, 1, Test.Pass>(),
-    // check<T.Head<any>, never, Test.Pass>(),
-    check<T.Head<never>, never, Test.Pass>(),
-])
+  check<T.Head<T>, 1, Test.Pass>(),
+  // check<T.Head<any>, never, Test.Pass>(),
+  check<T.Head<never>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // INCLUDES
@@ -249,46 +254,63 @@ checks([
 // No test needed (same as O.Includes)
 
 // ---------------------------------------------------------------------------------------
+// IndexOf
+check([
+  check<T.IndexOf<[1, 2, 3], 2>, 1, Test.Pass>(),
+  check<T.IndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>, 2, Test.Pass>(),
+  check<T.IndexOf<[0, 0, 0], 2>, -1, Test.Pass>(),
+  check<T.IndexOf<[string, 1, number, "a"], number>, 2, Test.Pass>(),
+  check<T.IndexOf<[string, 1, number, "a", any], any>, 4, Test.Pass>(),
+]);
+
+// ---------------------------------------------------------------------------------------
 // INTERSECT
 
-type t = T.Intersect<T, T1, 'default'>
+type t = T.Intersect<T, T1, "default">;
 
 type INTERSECT_T_T1_NUMBER_DEFAULT = [
-    1,
-    2,
-    '3' | undefined,
-    'xxxx',
-    {a: 'a'} & {b: 'b'},
-    string | number,
-    number,
-    object,
-    readonly [0, 1, 2?],
-    'xxxx' | undefined
+  1,
+  2,
+  "3" | undefined,
+  "xxxx",
+  { a: "a" } & { b: "b" },
+  string | number,
+  number,
+  object,
+  readonly [0, 1, 2?],
+  "xxxx" | undefined
 ];
 
 type INTERSECT_T_T1_NUMBER_EXTENDS = [
-    1,
-    2,
-    '3' | undefined,
-    'xxxx',
-    number | string,
-    number,
-    object,
-    readonly [0, 1, 2?]
+  1,
+  2,
+  "3" | undefined,
+  "xxxx",
+  number | string,
+  number,
+  object,
+  readonly [0, 1, 2?]
 ];
 
-type INTERSECT_T_T1_NUMBER_EQUALS = [
-    1,
-    2,
-    'xxxx',
-    object,
-];
+type INTERSECT_T_T1_NUMBER_EQUALS = [1, 2, "xxxx", object];
 
 checks([
-    check<T.Intersect<T, T1, 'default'>, INTERSECT_T_T1_NUMBER_DEFAULT, Test.Pass>(),
-    check<T.Intersect<T, T1, 'extends->'>, INTERSECT_T_T1_NUMBER_EXTENDS, Test.Pass>(),
-    check<T.Intersect<T, T1, 'equals'>, INTERSECT_T_T1_NUMBER_EQUALS, Test.Pass>(),
-])
+  check<
+    T.Intersect<T, T1, "default">,
+    INTERSECT_T_T1_NUMBER_DEFAULT,
+    Test.Pass
+  >(),
+  check<
+    T.Intersect<T, T1, "extends->">,
+    INTERSECT_T_T1_NUMBER_EXTENDS,
+    Test.Pass
+  >(),
+  check<
+    T.Intersect<T, T1, "equals">,
+    INTERSECT_T_T1_NUMBER_EQUALS,
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // INTERSECTKEYS
@@ -299,63 +321,63 @@ checks([
 // KEYSET
 
 checks([
-    check<T.KeySet<1, 6>, 1 | 2 | 3 | 4 | 5 | 6, Test.Pass>(),
-    check<T.KeySet<-5, -2>, -5 | -4 | -3 | -2, Test.Pass>(),
-])
+  check<T.KeySet<1, 6>, 1 | 2 | 3 | 4 | 5 | 6, Test.Pass>(),
+  check<T.KeySet<-5, -2>, -5 | -4 | -3 | -2, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // LAST
 
 checks([
-    check<T.Last<T>, 'xxxx' | readonly [0, 1, 2?] | undefined, Test.Pass>(),
-])
+  check<T.Last<T>, "xxxx" | readonly [0, 1, 2?] | undefined, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // LASTINDEX
 
-checks([
-    check<T.LastKey<[0, 1, 2?]>, 1 | 2, Test.Pass>(),
-])
+checks([check<T.LastKey<[0, 1, 2?]>, 1 | 2, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // LENGTH
 
-checks([
-    check<T.Length<[0, 1, 2?]>, 2 | 3, Test.Pass>(),
-])
+checks([check<T.Length<[0, 1, 2?]>, 2 | 3, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // LONGEST
 
 checks([
-    check<T.Longest<T, T1>, T1, Test.Pass>(),
-    check<T.Longest<T1, T>, T1, Test.Pass>(),
-    check<T.Longest<[0], [1]>, [0], Test.Pass>(),
-])
+  check<T.Longest<T, T1>, T1, Test.Pass>(),
+  check<T.Longest<T1, T>, T1, Test.Pass>(),
+  check<T.Longest<[0], [1]>, [0], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // MERGE
 
 checks([
-    // eslint-disable-next-line func-call-spacing
-    check<T.Merge<[0, 0, 0?], [1, 2, 3?]>, [0, 0, (0 | 3)?], Test.Pass>(),
-    check<T.Merge<[0, 0, 0?], [1, 2, 3]>, [0, 0, 0 | 3], Test.Pass>(),
-    check<T.Merge<[0?], [1, 2, 3]>, [0 | 1, 2, 3], Test.Pass>(),
-    check<T.Merge<[0?], [1, 2, 3]>, [2, 3?], Test.Fail>(),
-    check<T.Merge<[1, 2, 3?], [0, 0, 0]>, [1, 2, 3 | 0], Test.Pass>(),
-    check<T.Merge<[0, [1]], [1, [2, 3], 4], 'deep'>, [0, [1, 3], 4], Test.Pass>(),
-])
+  // eslint-disable-next-line func-call-spacing
+  check<T.Merge<[0, 0, 0?], [1, 2, 3?]>, [0, 0, (0 | 3)?], Test.Pass>(),
+  check<T.Merge<[0, 0, 0?], [1, 2, 3]>, [0, 0, 0 | 3], Test.Pass>(),
+  check<T.Merge<[0?], [1, 2, 3]>, [0 | 1, 2, 3], Test.Pass>(),
+  check<T.Merge<[0?], [1, 2, 3]>, [2, 3?], Test.Fail>(),
+  check<T.Merge<[1, 2, 3?], [0, 0, 0]>, [1, 2, 3 | 0], Test.Pass>(),
+  check<T.Merge<[0, [1]], [1, [2, 3], 4], "deep">, [0, [1, 3], 4], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // MERGEALL
 
 checks([
-    check<T.MergeAll<[0], [[1, 2, 3?]]>, [0, 2, 3?], Test.Pass>(),
-    check<T.MergeAll<[0], [[1, 2, 3]]>, [0, 2, 3], Test.Pass>(),
-    check<T.MergeAll<[0?], [[1, 2, 3]]>, [2, 3?], Test.Fail>(),
-    check<T.MergeAll<[1, 2, 3?], [[0, 0, 0]]>, [1, 2, 3 | 0], Test.Pass>(),
-    check<T.MergeAll<[0, [1]], [[1, [2, 3], 4]], 'deep'>, [0, [1, 3], 4], Test.Pass>(),
-])
+  check<T.MergeAll<[0], [[1, 2, 3?]]>, [0, 2, 3?], Test.Pass>(),
+  check<T.MergeAll<[0], [[1, 2, 3]]>, [0, 2, 3], Test.Pass>(),
+  check<T.MergeAll<[0?], [[1, 2, 3]]>, [2, 3?], Test.Fail>(),
+  check<T.MergeAll<[1, 2, 3?], [[0, 0, 0]]>, [1, 2, 3 | 0], Test.Pass>(),
+  check<
+    T.MergeAll<[0, [1]], [[1, [2, 3], 4]], "deep">,
+    [0, [1, 3], 4],
+    Test.Pass
+  >(),
+]);
 // ---------------------------------------------------------------------------------------
 // MERGEKEYS
 
@@ -365,17 +387,25 @@ checks([
 // MODIFY
 
 checks([
-    check<T.Modify<[9, string], [9, A.x?]>, [9, string?], Test.Pass>(),
-    check<T.Modify<[], [9, A.x]>, [9, never], Test.Pass>(),
-])
+  check<T.Modify<[9, string], [9, A.x?]>, [9, string?], Test.Pass>(),
+  check<T.Modify<[], [9, A.x]>, [9, never], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // NONNULLABLE
 
 checks([
-    check<T.NonNullable<[0 | undefined, 1, 2 | undefined]>, [0, 1, 2], Test.Pass>(),
-    check<T.NonNullable<[0 | undefined, 1, 2 | undefined], '2'>, [0 | undefined, 1, 2], Test.Pass>(),
-])
+  check<
+    T.NonNullable<[0 | undefined, 1, 2 | undefined]>,
+    [0, 1, 2],
+    Test.Pass
+  >(),
+  check<
+    T.NonNullable<[0 | undefined, 1, 2 | undefined], "2">,
+    [0 | undefined, 1, 2],
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // NONNULLABLEKEYS
@@ -386,9 +416,13 @@ checks([
 // NULLABLE
 
 checks([
-    check<T.Nullable<[0, 1, 2]>, [0 | undefined | null, 1 | undefined | null, 2 | undefined | null], Test.Pass>(),
-    check<T.Nullable<[0, 1, 2], '2'>, [0, 1, 2 | undefined | null], Test.Pass>(),
-])
+  check<
+    T.Nullable<[0, 1, 2]>,
+    [0 | undefined | null, 1 | undefined | null, 2 | undefined | null],
+    Test.Pass
+  >(),
+  check<T.Nullable<[0, 1, 2], "2">, [0, 1, 2 | undefined | null], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // NULLABLEKEYS
@@ -399,27 +433,27 @@ checks([
 // OBJECTOF
 
 checks([
-    check<T.ObjectOf<readonly [0]>, {readonly 0: 0}, Test.Pass>(),
-    check<T.ObjectOf<[0, 1, 2]>, {0: 0, 1: 1, 2: 2}, Test.Pass>(),
-    check<T.ObjectOf<[0, 1, 2?]>, {0: 0, 1: 1, 2?: 2}, Test.Pass>(),
-])
+  check<T.ObjectOf<readonly [0]>, { readonly 0: 0 }, Test.Pass>(),
+  check<T.ObjectOf<[0, 1, 2]>, { 0: 0; 1: 1; 2: 2 }, Test.Pass>(),
+  check<T.ObjectOf<[0, 1, 2?]>, { 0: 0; 1: 1; 2?: 2 }, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // OMIT
 
 checks([
-    check<T.Omit<[0, 1, 2?], '0'>, [1, 2 | undefined], Test.Pass>(),
-    check<T.Omit<[0, 1, 2?], '1' | '2'>, [0], Test.Pass>(),
-])
+  check<T.Omit<[0, 1, 2?], "0">, [1, 2 | undefined], Test.Pass>(),
+  check<T.Omit<[0, 1, 2?], "1" | "2">, [0], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // OPTIONAL
 
 checks([
-    check<T.Optional<[0, 1, 2]>, [0?, 1?, 2?], Test.Pass>(),
-    check<T.Optional<[0, 1, 2?]>, [0?, 1?, 2?], Test.Pass>(),
-    check<T.Optional<never>, never, Test.Pass>(),
-])
+  check<T.Optional<[0, 1, 2]>, [0?, 1?, 2?], Test.Pass>(),
+  check<T.Optional<[0, 1, 2?]>, [0?, 1?, 2?], Test.Pass>(),
+  check<T.Optional<never>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // OPTIONALKEYS
@@ -435,32 +469,36 @@ checks([
 // OPTIONAL
 
 checks([
-    check<T.Partial<[0, 1, 2]>, [0?, 1?, 2?], Test.Pass>(),
-    check<T.Partial<[0, 1, 2?]>, [0?, 1?, 2?], Test.Pass>(),
-    check<T.Partial<never>, never, Test.Pass>(),
-])
+  check<T.Partial<[0, 1, 2]>, [0?, 1?, 2?], Test.Pass>(),
+  check<T.Partial<[0, 1, 2?]>, [0?, 1?, 2?], Test.Pass>(),
+  check<T.Partial<never>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // PATCH
 
 checks([
-    check<T.Patch<[0], [1, 2, 3?]>, [0, 2, 3?], Test.Pass>(),
-    check<T.Patch<[0], [1, 2, 3]>, [0, 2, 3], Test.Pass>(),
-    check<T.Patch<[0?], [1, 2, 3]>, [2, 3?], Test.Fail>(),
-    check<T.Patch<[1, 2, 3?], [0, 0, 0]>, [1, 2, 3?], Test.Pass>(),
-    check<T.Patch<[0, [1]], [1, [2, 3], 4], 'deep'>, [0, [1, 3], 4], Test.Pass>(),
-])
+  check<T.Patch<[0], [1, 2, 3?]>, [0, 2, 3?], Test.Pass>(),
+  check<T.Patch<[0], [1, 2, 3]>, [0, 2, 3], Test.Pass>(),
+  check<T.Patch<[0?], [1, 2, 3]>, [2, 3?], Test.Fail>(),
+  check<T.Patch<[1, 2, 3?], [0, 0, 0]>, [1, 2, 3?], Test.Pass>(),
+  check<T.Patch<[0, [1]], [1, [2, 3], 4], "deep">, [0, [1, 3], 4], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // PATCHALL
 
 checks([
-    check<T.PatchAll<[0], [[1, 2, 3?]]>, [0, 2, 3?], Test.Pass>(),
-    check<T.PatchAll<[0], [[1, 2, 3]]>, [0, 2, 3], Test.Pass>(),
-    check<T.PatchAll<[0?], [[1, 2, 3]]>, [2, 3?], Test.Fail>(),
-    check<T.PatchAll<[1, 2, 3?], [[0, 0, 0]]>, [1, 2, 3?], Test.Pass>(),
-    check<T.PatchAll<[0, [1]], [[1, [2, 3], 4]], 'deep'>, [0, [1, 3], 4], Test.Pass>(),
-])
+  check<T.PatchAll<[0], [[1, 2, 3?]]>, [0, 2, 3?], Test.Pass>(),
+  check<T.PatchAll<[0], [[1, 2, 3]]>, [0, 2, 3], Test.Pass>(),
+  check<T.PatchAll<[0?], [[1, 2, 3]]>, [2, 3?], Test.Fail>(),
+  check<T.PatchAll<[1, 2, 3?], [[0, 0, 0]]>, [1, 2, 3?], Test.Pass>(),
+  check<
+    T.PatchAll<[0, [1]], [[1, [2, 3], 4]], "deep">,
+    [0, [1, 3], 4],
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // PATH
@@ -481,35 +519,35 @@ checks([
 // PICK
 
 checks([
-    check<T.Pick<[0, 1, 2], '0'>, [0], Test.Pass>(),
-    check<T.Pick<[0, 1, 2?], '1' | '2'>, [1, 2 | undefined], Test.Pass>(),
-])
+  check<T.Pick<[0, 1, 2], "0">, [0], Test.Pass>(),
+  check<T.Pick<[0, 1, 2?], "1" | "2">, [1, 2 | undefined], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // POP
 
 checks([
-    check<T.Pop<[1, 2, 3]>, [1, 2], Test.Pass>(),
-    check<T.Pop<[1, 2?, 3?]>, [1, 2?], Test.Pass>(),
-])
+  check<T.Pop<[1, 2, 3]>, [1, 2], Test.Pass>(),
+  check<T.Pop<[1, 2?, 3?]>, [1, 2?], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // PREPEND
 
 checks([
-    check<T.Prepend<[0, 1, 2, 3?], 4>, [4, 0, 1, 2, 3?], Test.Pass>(),
-    check<T.Prepend<[0, 1, 2, 3], [4, 5?]>, [[4, 5?], 0, 1, 2, 3], Test.Pass>(),
-    check<T.Prepend<never, [4, 5]>, never, Test.Pass>(),
-])
+  check<T.Prepend<[0, 1, 2, 3?], 4>, [4, 0, 1, 2, 3?], Test.Pass>(),
+  check<T.Prepend<[0, 1, 2, 3], [4, 5?]>, [[4, 5?], 0, 1, 2, 3], Test.Pass>(),
+  check<T.Prepend<never, [4, 5]>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // READONLY
 
 checks([
-    check<T.Readonly<[0, 1, 2]>, readonly [0, 1, 2], Test.Pass>(),
-    check<T.Readonly<[0, 1, 2?]>, readonly [0, 1, 2?], Test.Pass>(),
-    check<T.Readonly<never>, never, Test.Pass>(),
-])
+  check<T.Readonly<[0, 1, 2]>, readonly [0, 1, 2], Test.Pass>(),
+  check<T.Readonly<[0, 1, 2?]>, readonly [0, 1, 2?], Test.Pass>(),
+  check<T.Readonly<never>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // READONLYKEYS
@@ -520,19 +558,19 @@ checks([
 // REMOVE
 
 checks([
-    check<T.Remove<[0, 1, 2], 1, 1>, [0, 2], Test.Pass>(),
-    check<T.Remove<[0, 1, 2?], 1, 1>, [0, 2 | undefined], Test.Pass>(),
-    check<T.Remove<[0, 1, 2], 0, 2>, [], Test.Pass>(),
-    check<T.Remove<[0, 1, 2?], -1, 10>, [], Test.Pass>(),
-])
+  check<T.Remove<[0, 1, 2], 1, 1>, [0, 2], Test.Pass>(),
+  check<T.Remove<[0, 1, 2?], 1, 1>, [0, 2 | undefined], Test.Pass>(),
+  check<T.Remove<[0, 1, 2], 0, 2>, [], Test.Pass>(),
+  check<T.Remove<[0, 1, 2?], -1, 10>, [], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // REPEAT
 
 checks([
-    check<T.Repeat<1, 3>, [1, 1, 1], Test.Pass>(),
-    check<T.Repeat<1, never>, never, Test.Pass>(),
-])
+  check<T.Repeat<1, 3>, [1, 1, 1], Test.Pass>(),
+  check<T.Repeat<1, never>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // REPLACE
@@ -543,38 +581,31 @@ checks([
 // REQUIRED
 
 checks([
-    check<T.Required<[0, 1, 2?]>, [0, 1, 2], Test.Pass>(),
-    check<T.Required<[0, 1?, 2?]>, [0, 1, 2], Test.Pass>(),
-    check<T.Required<[0, 1, 2]>, [0, 1, 2], Test.Pass>(),
-])
+  check<T.Required<[0, 1, 2?]>, [0, 1, 2], Test.Pass>(),
+  check<T.Required<[0, 1?, 2?]>, [0, 1, 2], Test.Pass>(),
+  check<T.Required<[0, 1, 2]>, [0, 1, 2], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // REVERSE
 
 checks([
-    check<T.Reverse<[1, 2, 3]>, [3, 2, 1], Test.Pass>(),
-    check<T.Reverse<[1, 2, 3?]>, [3 | undefined, 2, 1], Test.Pass>(),
-])
+  check<T.Reverse<[1, 2, 3]>, [3, 2, 1], Test.Pass>(),
+  check<T.Reverse<[1, 2, 3?]>, [3 | undefined, 2, 1], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // SELECT
 
-type SELECT_T_NUMBER_EXTENDS = [
-    1,
-    2,
-    string | number,
-    number
-];
+type SELECT_T_NUMBER_EXTENDS = [1, 2, string | number, number];
 
-type SELECT_T_NUMBER_EQUALS = [
-    number
-];
+type SELECT_T_NUMBER_EQUALS = [number];
 
 checks([
-    check<T.Select<T, number, 'default'>, SELECT_T_NUMBER_EXTENDS, Test.Pass>(),
-    check<T.Select<T, number, 'extends->'>, SELECT_T_NUMBER_EXTENDS, Test.Pass>(),
-    check<T.Select<T, number, 'equals'>, SELECT_T_NUMBER_EQUALS, Test.Pass>(),
-])
+  check<T.Select<T, number, "default">, SELECT_T_NUMBER_EXTENDS, Test.Pass>(),
+  check<T.Select<T, number, "extends->">, SELECT_T_NUMBER_EXTENDS, Test.Pass>(),
+  check<T.Select<T, number, "equals">, SELECT_T_NUMBER_EQUALS, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // SELECTKEYS
@@ -585,28 +616,28 @@ checks([
 // SHORTEST
 
 checks([
-    check<T.Shortest<T, T1>, T, Test.Pass>(),
-    check<T.Shortest<T1, T>, T, Test.Pass>(),
-    check<T.Shortest<[0], [1]>, [0], Test.Pass>(),
-])
+  check<T.Shortest<T, T1>, T, Test.Pass>(),
+  check<T.Shortest<T1, T>, T, Test.Pass>(),
+  check<T.Shortest<[0], [1]>, [0], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // TAIL
 
 checks([
-    check<T.Tail<[1, 2, 3?, 4?]>, [2, 3?, 4?], Test.Pass>(),
-    check<T.Tail<[]>, [], Test.Pass>(),
-    check<T.Tail<never>, never, Test.Pass>(),
-])
+  check<T.Tail<[1, 2, 3?, 4?]>, [2, 3?, 4?], Test.Pass>(),
+  check<T.Tail<[]>, [], Test.Pass>(),
+  check<T.Tail<never>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // TAKE
 
 checks([
-    check<T.Take<[1, 2, 3?, 4?], 2, '->'>, [1, 2], Test.Pass>(),
-    check<T.Take<[1, 2, 3?, 4?], 2, '<-'>, [3?, 4?], Test.Pass>(), // nothing happens
-    check<T.Take<[1, 2, 3, 4], 2, '<-'>, [3, 4], Test.Pass>(), // nothing happens
-])
+  check<T.Take<[1, 2, 3?, 4?], 2, "->">, [1, 2], Test.Pass>(),
+  check<T.Take<[1, 2, 3?, 4?], 2, "<-">, [3?, 4?], Test.Pass>(), // nothing happens
+  check<T.Take<[1, 2, 3, 4], 2, "<-">, [3, 4], Test.Pass>(), // nothing happens
+]);
 
 // ---------------------------------------------------------------------------------------
 // TUPLE
@@ -617,9 +648,13 @@ checks([
 // UNDEFINABLE
 
 checks([
-    check<T.Undefinable<[0, 1, 2]>, [0 | undefined, 1 | undefined, 2 | undefined], Test.Pass>(),
-    check<T.Undefinable<[0, 1, 2], '2'>, [0, 1, 2 | undefined], Test.Pass>(),
-])
+  check<
+    T.Undefinable<[0, 1, 2]>,
+    [0 | undefined, 1 | undefined, 2 | undefined],
+    Test.Pass
+  >(),
+  check<T.Undefinable<[0, 1, 2], "2">, [0, 1, 2 | undefined], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // UNDEFINABLEKEYS
@@ -630,55 +665,54 @@ checks([
 // LIST
 
 checks([
-    check<T.List<string>, readonly string[], Test.Pass>(),
-    check<T.List<never>, readonly never[], Test.Pass>(),
-])
+  check<T.List<string>, readonly string[], Test.Pass>(),
+  check<T.List<never>, readonly never[], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // UNIONIZE
 
 checks([
-    check<T.Unionize<[2], string[]>, [2 | string | undefined], Test.Pass>(),
-    check<T.Unionize<string[], [2]>, Array<string | 2>, Test.Pass>(),
-    check<T.Unionize<[1], [2, 3]>, [1 | 2], Test.Pass>(),
-])
+  check<T.Unionize<[2], string[]>, [2 | string | undefined], Test.Pass>(),
+  check<T.Unionize<string[], [2]>, Array<string | 2>, Test.Pass>(),
+  check<T.Unionize<[1], [2, 3]>, [1 | 2], Test.Pass>(),
+]);
 
 // --------------------------------------------------------------------------------?-------
 // UNIONOF
 
 checks([
-    check<T.UnionOf<[1, 2, 3?]>, 1 | 2 | 3 | undefined, Test.Pass>(),
-    check<T.UnionOf<[]>, never, Test.Pass>(),
-])
+  check<T.UnionOf<[1, 2, 3?]>, 1 | 2 | 3 | undefined, Test.Pass>(),
+  check<T.UnionOf<[]>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // UNNEST
 
-
 checks([
-    check<T.UnNest<[[1], [2], [3, [4]]]>, [1, 2, 3, [4]], Test.Pass>(),
-    check<T.UnNest<number[][][] | number[]>, number[][] | number[], Test.Pass>(),
-    check<T.UnNest<any>, any[], Test.Pass>(),
-])
+  check<T.UnNest<[[1], [2], [3, [4]]]>, [1, 2, 3, [4]], Test.Pass>(),
+  check<T.UnNest<number[][][] | number[]>, number[][] | number[], Test.Pass>(),
+  check<T.UnNest<any>, any[], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // UPDATE
 
 checks([
-    check<T.Update<string[], number, A.x | 2>, Array<(string | 2)>, Test.Pass>(),
-    check<T.Update<[1], 0, 2>, [2], Test.Pass>(),
-])
+  check<T.Update<string[], number, A.x | 2>, Array<string | 2>, Test.Pass>(),
+  check<T.Update<[1], 0, 2>, [2], Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // WRITABLE
 
-type WRITABLE_W_T_ARR = ['a', 'b'];
-type WRITABLE_R_T_ARR = readonly ['a', 'b'];
+type WRITABLE_W_T_ARR = ["a", "b"];
+type WRITABLE_R_T_ARR = readonly ["a", "b"];
 
 checks([
-    check<T.Writable<WRITABLE_W_T_ARR>, WRITABLE_W_T_ARR, Test.Pass>(),
-    check<T.Writable<WRITABLE_R_T_ARR>, WRITABLE_W_T_ARR, Test.Pass>(),
-])
+  check<T.Writable<WRITABLE_W_T_ARR>, WRITABLE_W_T_ARR, Test.Pass>(),
+  check<T.Writable<WRITABLE_R_T_ARR>, WRITABLE_W_T_ARR, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // WRITABLEKEYS
@@ -689,14 +723,26 @@ checks([
 // ZIP
 
 checks([
-    check<T.Zip<['a', 'b', 'c'], [1, 2, 3, 4]>, [['a', 1], ['b', 2], ['c', 3]], Test.Pass>(),
-    check<T.Zip<['a', 'b'], []>, [['a', undefined], ['b', undefined]], Test.Pass>(),
-])
+  check<
+    T.Zip<["a", "b", "c"], [1, 2, 3, 4]>,
+    [["a", 1], ["b", 2], ["c", 3]],
+    Test.Pass
+  >(),
+  check<
+    T.Zip<["a", "b"], []>,
+    [["a", undefined], ["b", undefined]],
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // ZIPOBJ
 
 checks([
-    check<T.ZipObj<['a', 'b', 'c'], [1, 2, 3, 4]>, {a: 1, b: 2, c: 3}, Test.Pass>(),
-    check<T.ZipObj<['a', 'b'], []>, {a: undefined, b: undefined}, Test.Pass>(),
-])
+  check<
+    T.ZipObj<["a", "b", "c"], [1, 2, 3, 4]>,
+    { a: 1; b: 2; c: 3 },
+    Test.Pass
+  >(),
+  check<T.ZipObj<["a", "b"], []>, { a: undefined; b: undefined }, Test.Pass>(),
+]);

--- a/tests/String.ts
+++ b/tests/String.ts
@@ -1,48 +1,60 @@
-import {Test, S} from '../sources'
+import { Test, S } from "../sources";
 
-const {checks, check} = Test
+const { checks, check } = Test;
 
 // ///////////////////////////////////////////////////////////////////////////////////////
 // STRING ////////////////////////////////////////////////////////////////////////////////
 
-type S =
-    | 'hola'
-    | 'ciao!'
+type S = "hola" | "ciao!";
 
 // ---------------------------------------------------------------------------------------
 // AT
 
 checks([
-    check<S.At<S, 1 | 2>, 'o' | 'l' | 'i' | 'a', Test.Pass>(),
-    check<S.At<S, 20>, undefined, Test.Pass>(),
-])
+  check<S.At<S, 1 | 2>, "o" | "l" | "i" | "a", Test.Pass>(),
+  check<S.At<S, 20>, undefined, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // JOIN
 
-checks([
-    check<S.Join<S.Split<S, ''>>, S, Test.Pass>(),
-])
+checks([check<S.Join<S.Split<S, "">>, S, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // LENGTH
 
-checks([
-    check<S.Length<S>, 4 | 5, Test.Pass>(),
-])
+checks([check<S.Length<S>, 4 | 5, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // REPLACE
 
 checks([
-    check<S.Replace<'$1 is nice. $1 is good.', '$1', 'Jane'>, 'Jane is nice. Jane is good.', Test.Pass>(),
-])
+  check<
+    S.Replace<"$1 is nice. $1 is good.", "$1", "Jane">,
+    "Jane is nice. Jane is good.",
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // SPLIT
 
 checks([
-    check<S.Split<S>, ['h', 'o', 'l', 'a'] | ['c', 'i', 'a', 'o', '!'], Test.Pass>(),
-    check<S.Split<'a.b.c', '.'>, ['a', 'b', 'c'], Test.Pass>(),
-    check<S.Split<'a.b.c.', '.'>, ['a', 'b', 'c', ''], Test.Pass>(),
-])
+  check<
+    S.Split<S>,
+    ["h", "o", "l", "a"] | ["c", "i", "a", "o", "!"],
+    Test.Pass
+  >(),
+  check<S.Split<"a.b.c", ".">, ["a", "b", "c"], Test.Pass>(),
+  check<S.Split<"a.b.c.", ".">, ["a", "b", "c", ""], Test.Pass>(),
+]);
+
+// ---------------------------------------------------------------------------------------
+// StringNumToNum
+
+checks([
+  check<S.StringNumToNum<"0">, 0, Test.Pass>(),
+  check<S.StringNumToNum<"1">, 1, Test.Pass>(),
+  check<S.StringNumToNum<"63">, 63, Test.Pass>(),
+  check<S.StringNumToNum<"64">, 64, Test.Fail>(),
+]);

--- a/tests/Union.ts
+++ b/tests/Union.ts
@@ -1,6 +1,6 @@
-import {Test, U} from '../sources'
+import { Test, U } from "../sources";
 
-const {checks, check} = Test
+const { checks, check } = Test;
 
 // ///////////////////////////////////////////////////////////////////////////////////////
 // UNION /////////////////////////////////////////////////////////////////////////////////
@@ -8,16 +8,29 @@ const {checks, check} = Test
 // ---------------------------------------------------------------------------------------
 // DIFF
 
-checks([
-    check<U.Diff<1 | 2, 1 | 3>, 2 | 3, Test.Pass>(),
-])
+checks([check<U.Diff<1 | 2, 1 | 3>, 2 | 3, Test.Pass>()]);
+
+// ---------------------------------------------------------------------------------------
+// EnumValue
+enum StrValueEnum {
+  T1 = "1",
+  T2 = "2",
+  T3 = "3",
+}
+
+enum NumValueEnum {
+  T1 = 1,
+  T2 = 2,
+  T3 = 3,
+}
+
+checks([check<U.EnumValue<StrValueEnum>, "1" | "2" | "3", Test.Pass>()]);
+checks([check<U.EnumValue<NumValueEnum>, 1 | 2 | 3, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // EXCLUDE
 
-checks([
-    check<U.Exclude<1 | 2 | 3, 3>, 1 | 2, Test.Pass>(),
-])
+checks([check<U.Exclude<1 | 2 | 3, 3>, 1 | 2, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // FILTER
@@ -28,97 +41,96 @@ checks([
 // HAS
 
 checks([
-    check<U.Has<1 | 2 | 3, string>, 0, Test.Pass>(),
-    check<U.Has<1 | 2 | 3, 1>, 1, Test.Pass>(),
-])
+  check<U.Has<1 | 2 | 3, string>, 0, Test.Pass>(),
+  check<U.Has<1 | 2 | 3, 1>, 1, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // INTERSECT
 
 checks([
-    check<U.Intersect<1 | 2 | 3 | {a: 1}, {a: 1} | 4 | 1>, {a: 1} | 1, Test.Pass>(),
-])
+  check<
+    U.Intersect<1 | 2 | 3 | { a: 1 }, { a: 1 } | 4 | 1>,
+    { a: 1 } | 1,
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // INTERSECTOF
 
-checks([
-    check<U.IntersectOf<1 | 2 | 3>, 1 & 2 & 3, Test.Pass>(),
-])
+checks([check<U.IntersectOf<1 | 2 | 3>, 1 & 2 & 3, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // LAST
 
 checks([
-    // check<U.Last<1 | 2 | 3>, 3, Test.Pass>(), // order not guaranteed
-    // check<U.Last<3 | 2 | 0>, 0, Test.Pass>(), // order not guaranteed
-])
+  // check<U.Last<1 | 2 | 3>, 3, Test.Pass>(), // order not guaranteed
+  // check<U.Last<3 | 2 | 0>, 0, Test.Pass>(), // order not guaranteed
+]);
 
 // ---------------------------------------------------------------------------------------
 // LISTOF
 
 checks([
-    // check<U.ListOf<1 | 2 | 3>, [1, 2, 3], Test.Pass>(), // order not guaranteed
-])
+  // check<U.ListOf<1 | 2 | 3>, [1, 2, 3], Test.Pass>(), // order not guaranteed
+]);
 
 // ---------------------------------------------------------------------------------------
 // MERGE
 
-type U_MERGE = {a: string, e: 22} | {b?: number, c: 42} | {b?: string, c?: 48, d: 21, e: 23};
+type U_MERGE =
+  | { a: string; e: 22 }
+  | { b?: number; c: 42 }
+  | { b?: string; c?: 48; d: 21; e: 23 };
 type MERGE_U = {
-    a: string;
-    b?: string | number;
-    c: 42 | 48;
-    d: 21;
-    e: 22 | 23;
+  a: string;
+  b?: string | number;
+  c: 42 | 48;
+  d: 21;
+  e: 22 | 23;
 };
 
-checks([
-    check<U.Merge<U_MERGE>, MERGE_U, Test.Pass>(),
-])
+checks([check<U.Merge<U_MERGE>, MERGE_U, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // NONNULLABLE
 
-checks([
-    check<U.NonNullable<1 | 2 | undefined>, 1 | 2, Test.Pass>(),
-])
+checks([check<U.NonNullable<1 | 2 | undefined>, 1 | 2, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // NULLABLE
 
-checks([
-    check<U.Nullable<1 | 2>, 1 | 2 | undefined | null, Test.Pass>(),
-])
+checks([check<U.Nullable<1 | 2>, 1 | 2 | undefined | null, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // POP
 
 checks([
-    // check<U.Pop<1 | 2 | 3>, 1 | 2, Test.Pass>(), // order not guaranteed
-    check<U.Pop<1>, never, Test.Pass>(),
-])
+  // check<U.Pop<1 | 2 | 3>, 1 | 2, Test.Pass>(), // order not guaranteed
+  check<U.Pop<1>, never, Test.Pass>(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // REPLACE
 
-checks([
-    check<U.Replace<1 | 2 | 3, 1 | 2, 'a'>, 'a' | 3, Test.Pass>(),
-])
+checks([check<U.Replace<1 | 2 | 3, 1 | 2, "a">, "a" | 3, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // SELECT
 
-checks([
-    check<U.Select<1 | 2 | 'a', number>, 1 | 2, Test.Pass>(),
-])
+checks([check<U.Select<1 | 2 | "a", number>, 1 | 2, Test.Pass>()]);
 
 // ---------------------------------------------------------------------------------------
 // STRICT
 
 checks([
-    check<U.Strict<{a: 0} | {b: 0}>, {a: 0, b?: never} | {a?: never, b: 0}, Test.Pass>(),
-])
+  check<
+    U.Strict<{ a: 0 } | { b: 0 }>,
+    { a: 0; b?: never } | { a?: never; b: 0 },
+    Test.Pass
+  >(),
+]);
 
 // ---------------------------------------------------------------------------------------
 // UNION


### PR DESCRIPTION
## 🎁 Pull Request

<!-- Fill the following checklist. -->
* [✅] Used a clear / meaningful title for this pull request
* [✅] Tested the changes in your own code (on your projects)
* [✅] Added / Edited tests to reflect changes (`tests` folder)
* [✅] Have read the **Contributing** part of the **Readme**
* [✅] Passed `npm test`

<!-- Complete the following parts. -->


#### Why have you made changes?

Sometimes we need to change the enumerated value into a union type.
stackoverflow:
https://stackoverflow.com/questions/52393730/typescript-string-literal-union-type-from-enum
```ts
enum StrValueEnum {
  T1 = "1",
  T2 = "2",
  T3 = "3",
}


enum NumValueEnum {
  T1 = 1,
  T2 = 2,
  T3 = 3,
}

`${StrValueEnum}` // Type is "1" | "2" | "3",that is right
`${NumValueEnum}` // Type is "1" | "2" | "3",that is wrong
```
but sorry about I don't know how to fix lint，Command not found. If this idea is OK，plz tell me how to fix.

